### PR TITLE
kpkginstall: abort when the issue is caused by the OS

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -46,7 +46,7 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
 
   if [ $? -ne 0 ]; then
     echo "Failed to extract package ${KPKG}" | tee -a ${OUTPUTFILE}
-    report_result ${TEST} FAIL 4
+    rhts-abort -t recipe
     exit 1
   fi
 
@@ -105,7 +105,7 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
 
   if [ $? -ne 0 ]; then
     echo "Failed installing kernel ${KVER}" | tee -a ${OUTPUTFILE}
-    report_result ${TEST} FAIL 5
+    rhts-abort -t recipe
     exit 1
   fi
 
@@ -139,6 +139,6 @@ else
     fi
   else
     echo "Kernel version after reboot is not '${KVER}': '${ckver}'" | tee -a ${OUTPUTFILE}
-    report_result ${TEST} FAIL 6
+    rhts-abort -t recipe
   fi
 fi


### PR DESCRIPTION
Inability to extract the tarball would most likely indicate lack of disk
space or denied permissions for the user, not a problem with the kernel.
Similarly, having a different kernel booted after the installation
completed could be (and we did run into this situation) caused by a bug
in grub.

We'll be transitioning to treating this task as a normal test. Therefore
the only thing that should report a real failure is a kernel panic
during the boot.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>