### PR TITLE
Increase timeout for kpkginstall

### DIFF
--- a/distribution/kpkginstall/Makefile
+++ b/distribution/kpkginstall/Makefile
@@ -41,7 +41,7 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Description:     Install kernel from a tarball" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
+	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPL" >> $(METADATA)


### PR DESCRIPTION
Downloading the tarball can take longer than expected.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>