### PR TITLE
Temporarily disable migrate_pages03 from running

### DIFF
--- a/distribution/ltp/lite/configs/RHELKT1LITE.20180926
+++ b/distribution/ltp/lite/configs/RHELKT1LITE.20180926
@@ -651,7 +651,8 @@ memcpy01 memcpy01
 migrate_pages01 migrate_pages01
 # See https://github.com/linux-test-project/ltp/issues/407
 #migrate_pages02 migrate_pages02
-migrate_pages03 migrate_pages03
+# (Temporarily) disable due to https://github.com/linux-test-project/ltp/issues/431
+#migrate_pages03 migrate_pages03
 
 mlockall01 mlockall01
 mlockall02 mlockall02


### PR DESCRIPTION
There is an unresolved issue with the test timeouting on aarch64.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>