### PR TITLE
add metadata file to include Fedora dependencies

### DIFF
--- a/standards/usex/1.9-29/metadata
+++ b/standards/usex/1.9-29/metadata
@@ -1,0 +1,16 @@
+[General]
+name=/kernel/standards/usex/1.9-29
+owner=Kernel General Test Team <kernel-general-test-team@redhat.com>
+description=Dave Anderson's Usex test 1.9-29
+license=CC0 1.0 Universal
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=make run
+max_time=30m
+dependencies[RedHatEnterpriseLinux6]=xorg-x11-server-devel;kernel-headers;ncurses-devel
+dependencies[RedHatEnterpriseLinux7]=xorg-x11-server-devel;kernel-headers;ncurses-devel
+dependencies[RedHatEnterpriseLinux8]=xorg-x11-server-devel;kernel-headers;glibc-static;ncurses-devel
+dependencies[Fedora28]=xorg-x11-server-devel;kernel-headers;glibc-static;ncurses-devel
+dependencies[Fedora29]=xorg-x11-server-devel;kernel-headers;glibc-static;ncurses-devel


### PR DESCRIPTION
@veruu in order to enable usex on stable release we need to enable dependencies for Fedora, otherwise it will fail. 