### PR TITLE
add generic/084, generic/139, generic/394 to known isssues file

### DIFF
--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -1,1 +1,4 @@
 generic/466
+generic/084
+generic/139
+generic/394


### PR DESCRIPTION
We have the following three cases failing in CKI currently:

generic/084: Seen only once so far, and is related to a real data corruption

generic/139: This one may be related to a test case issue on ppc64le

generic/394: Failed generic/394 because the test filesystem had a dirty log after
unmount. No unmount record appears to be in the log, and xfs_repair
reported the log was dirty. This was seen multiple times so far in CKI.

We have internal tickets to track each case, and each one will be handled separately, we can remove from known_issues file after they've been resolved. 
