### PR TITLE
Disable generic/471 xfstest

### DIFF
--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -2,3 +2,4 @@ generic/466
 generic/084
 generic/139
 generic/394
+generic/471


### PR DESCRIPTION
The ext4:generic/471 test started failing regularly with latest
RHEL8 compose, confirmed with @idorax  this is performance
related and should be disabled for now.