### PR TITLE
ltp/lite ptrace07 test failed on AMD system

### DIFF
--- a/distribution/ltp/lite/configs/RHELKT1LITE.20180926
+++ b/distribution/ltp/lite/configs/RHELKT1LITE.20180926
@@ -920,7 +920,8 @@ ptrace04 ptrace04
 ptrace05 ptrace05
 # Broken test; See: testcases/kernel/syscalls/ptrace/Makefile for more details.
 #ptrace06 ptrace06
-ptrace07 ptrace07
+# Broken test; ltp/lite ptrace07 test failed on AMD system
+#ptrace07 ptrace07
 
 pwrite01 pwrite01
 pwrite02 pwrite02


### PR DESCRIPTION
ptrace07 test will fail on AMD systems, the internal bz was closed
as "CLOSED NOTABUG", the test will need to be updated in order to
workaround it, see internal ticket #409 for more details.