### PR TITLE
Initial commit for ltp-lite standard test interface

### DIFF
--- a/distribution/ltp/lite/runtest.sh
+++ b/distribution/ltp/lite/runtest.sh
@@ -205,4 +205,8 @@ ltp_lite_run
 
 ltp_lite_end
 
-exit 0
+if [ "$result_r" = "PASS" ]; then
+       exit 0
+else
+       exit 1
+fi

--- a/distribution/ltp/tests.yml
+++ b/distribution/ltp/tests.yml
@@ -1,0 +1,11 @@
+---
+# Tests that run in classic context
+- hosts: localhost
+  roles:
+  - role: standard-test-basic
+    tags:
+    - classic
+    tests:
+    - ltp-lite:
+        dir: "lite"
+        run: make run


### PR DESCRIPTION
This will enable DCI team to run ltp-lite using the standard test interface, the exit code needs to be set appropriately to allow Ansible to report the result correctly in STI. There is also one additional tests.yml playbook which will be ignored unless running it directly with Ansible.