### PR TITLE
Sanitize sanity test for loop device and move to the public repo

### DIFF
--- a/filesystems/loopdev/sanity/Makefile
+++ b/filesystems/loopdev/sanity/Makefile
@@ -1,0 +1,81 @@
+# The name of the package under test
+PACKAGE_NAME=kernel
+
+# The toplevel namespace within which the test lives.
+TOPLEVEL_NAMESPACE=/$(PACKAGE_NAME)
+
+# The version of the test rpm that gets
+#  created / submitte
+export TESTVERSION=1.0
+
+# The path of the test below the package
+RELATIVE_PATH=filesystems/loopdev/sanity
+
+# The relative path name to the test
+export TEST=$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
+
+LOOKASIDE=$(shell echo $$LOOKASIDE)
+LOOKASIDE_UPSTREAM=http://www.iozone.org/src/current
+ifeq (,$(LOOKASIDE))
+	LOOKASIDE=$(LOOKASIDE_UPSTREAM)
+endif
+
+# Name of the tar file that will be bundled
+TARGET=iozone3_487
+
+FILES=	$(METADATA)      \
+	runtest.sh       \
+	Makefile
+
+clean:
+	$(RM) *~ rm $(METADATA)
+	rm -rf $(TARGET) rh-tests-kernel-*.rpm
+	rm -rf fs_mark $(TARGET).tar
+	rm -f iozone *.txt
+	rm -f runtest
+
+runtest: runtest.sh
+	cp $< $@ && chmod +x $@
+
+run: build
+	./runtest
+
+build: $(METADATA) $(TARGET) runtest
+	make -C $(TARGET)/src/current/ linux
+	cp -f $(TARGET)/src/current/iozone ./
+
+$(TARGET).tar:
+	wget $(LOOKASIDE)/$(TARGET).tar || true
+	if [ ! -e $(TARGET).tar ]; then \
+		wget $(LOOKASIDE_BOS)/$(TARGET).tar; \
+	fi
+
+$(TARGET): $(TARGET).tar
+	tar -xvf $(TARGET).tar
+
+# Include a global make rules file
+include /usr/share/rhts/lib/rhts-make.include
+
+showmeta: $(METADATA)
+	@cat $(METADATA)
+	@rhts-lint $(METADATA)
+
+$(METADATA):
+	touch $(METADATA)
+	@echo "Name:		$(TEST)"	> $(METADATA)
+	@echo "Description:	Sanity test for loop device" >> $(METADATA)
+	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
+	@echo "TestTime:	15m"		>> $(METADATA)
+	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
+	@echo "Releases:	RHEL7 Fedorarawhide" >> $(METADATA)
+	@echo "#Architectures:	All"		>> $(METADATA)
+	@echo "Destructive:	no"		>> $(METADATA)
+	@echo "Type:            KernelTier0 KernelTier1"    >> $(METADATA)
+	@echo "Priority:	Normal"		>> $(METADATA)
+	@echo "RunFor:		kernel"		>> $(METADATA)
+	@echo "Requires:	kernel-devel"	>> $(METADATA)
+	@echo "Requires:	gcc"            >> $(METADATA)
+	@echo "Requires:	make"           >> $(METADATA)
+	@echo "Requires:	glibc-static"   >> $(METADATA)
+	@echo "Owner:		Jan Stancek <jstancek@redhat.com>" >> $(METADATA)
+	@echo "License:		GPLv2"		>> $(METADATA)

--- a/filesystems/loopdev/sanity/PURPOSE
+++ b/filesystems/loopdev/sanity/PURPOSE
@@ -1,0 +1,5 @@
+This is sanity test for loop device, which will mount
+various filesystems and stress them lightly with iozone.
+
+This test should reveal fatal problems before we see them
+in Anaconda (like Bug 948251).

--- a/filesystems/loopdev/sanity/runtest.sh
+++ b/filesystems/loopdev/sanity/runtest.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+# Source the common test script helpers
+. /usr/bin/rhts_environment.sh
+
+PS4='+ $(date "+%s.%N")\011 '
+set -x
+
+storage_path=/mnt/testarea/loopdev_test.img
+mnt_path=/mnt/loopsanity
+
+# skip btrfs for now, since mkfs.btrfs refuses to work on file
+filesystems="ext2 ext3 ext4 xfs"
+declare -A mkfs_args
+mkfs_args[ext2]="-F $storage_path"
+mkfs_args[ext3]="-F $storage_path"
+mkfs_args[ext4]="-F $storage_path"
+mkfs_args[xfs]="-f -d file,size=512m,name=$storage_path"
+mkfs_args[btrfs]="-f $storage_path"
+
+RunTest()
+{
+    fs=$1
+
+    mkfs.$fs ${mkfs_args[$fs]} 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed creating fs:$fs"
+        return 2
+    fi
+
+    mkdir -p $mnt_path
+    mount -o loop $storage_path $mnt_path
+    if [ $? -ne 0 ]; then
+        echo "Failed mounting $storage_path to $mnt_path"
+        return 3
+    fi
+
+    ./iozone -f $mnt_path/testfile -B -s 32535 -m 2>&1
+    if [ $? -ne 0 ]; then
+        killall -9 iozone
+        umount $mnt_path
+        echo "iozone failed"
+        return 4
+    fi
+
+    umount $mnt_path
+    if [ $? -ne 0 ]; then
+        echo "Failed umounting $mnt_path"
+        return 5
+    fi
+
+    return 0
+}
+
+echo "Test is starting." | tee -a $OUTPUTFILE
+fallocate -l512M $storage_path 2>&1 >> $OUTPUTFILE
+if [ $? -ne 0 ]; then
+    echo "Failed creating $storage_path" | tee -a $OUTPUTFILE
+    exit 1
+fi
+
+for fs in $filesystems; do
+    if command -v mkfs.$fs; then
+        echo "Starting test for $fs" | tee -a $OUTPUTFILE
+        RunTest $fs >> $OUTPUTFILE 2>&1
+        ret=$?
+        if [ $ret -eq 0 ]; then
+            echo "$fs PASSed" | tee -a $OUTPUTFILE
+            report_result $fs PASS 0
+        else
+            echo "$fs FAILed" | tee -a $OUTPUTFILE
+            report_result $fs FAIL $ret
+        fi
+        cat $OUTPUTFILE
+        echo > $OUTPUTFILE
+    fi
+done
+
+rm -f $storage_path 2>&1 >> $OUTPUTFILE
+
+echo "Test finished" | tee -a $OUTPUTFILE
+report_result finished PASS 0
+
+exit 0


### PR DESCRIPTION
This is to port test case `/kernel/loopdev/sanity` to public repo, and the latest iozone [1] is used. Please help to review, thanks!
[1] http://www.iozone.org/src/current/iozone3_487.tar