### PR TITLE
disable setsockopt03 in config as well

### DIFF
--- a/distribution/ltp/lite/configs/RHELKT1LITE.20190115
+++ b/distribution/ltp/lite/configs/RHELKT1LITE.20190115
@@ -1240,7 +1240,7 @@ setsid01 setsid01
 
 setsockopt01 setsockopt01
 setsockopt02 setsockopt02
-setsockopt03 setsockopt03
+# setsockopt03 setsockopt03 # work around Bug 1672242 - clash between linux/in.h and netinet/in.h
 
 settimeofday01 settimeofday01
 settimeofday02 settimeofday02


### PR DESCRIPTION
hi @veruu I noticed the rhel7 job failed in CI since I forgot to disable in config file as well, it will fail since the file was removed to avoid the compilation errors:
```
+	# work around Bug 1672242 - clash between linux/in.h and netinet/in.h
+	if grep -q "release 7" /etc/redhat-release; then rm -f $(TARGET)/testcases/kernel/syscalls/setsockopt/setsockopt03.c || true; fi

<<<test_start>>>
tag=setsockopt03 stime=1550839174
cmdline="setsockopt03"
contacts=""
analysis=exit
<<<test_output>>>
<<<execution_status>>>
initiation_status="pan(31271): execvp of 'setsockopt03' (tag setsockopt03) failed.  errno:2  No such file or directory"
duration=0 termination_type=exited termination_id=2 corefile=no
cutime=0 cstime=0
<<<test_end>>>
```