### PR TITLE
fixup kpkginstall in ppc64le

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -16,7 +16,7 @@ function get_kpkg_ver()
             ;;
     *)
             # Grab the kernel version from the provided repo directly
-            ${YUM} --disablerepo="*" --enablerepo="kernel-cki" list "${AVAILABLE}" kernel --showduplicates | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
+            ${YUM} -q --disablerepo="*" --enablerepo="kernel-cki" list "${AVAILABLE}" kernel --showduplicates | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
             ;;
   esac
 }


### PR DESCRIPTION
Apparently, the output of yum can sometimes confuse the 'yum list'
command, which is a subject of this patch. We end-up with two lines and
the first is set to KVER, resulting in nonsense.

This patch fixes it.

Signed-off-by: Jakub Racek <jracek@redhat.com>