### PR TITLE
ltp/include: backport patches for test fixing

### DIFF
--- a/distribution/ltp/include/ltp-make.include
+++ b/distribution/ltp/include/ltp-make.include
@@ -161,6 +161,10 @@ ifeq ($(TESTVERSION),20190115)
 	@$(PATCH) < $(ABS_DIR)/INTERNAL/0001-shmat03-ignore-EACCES.patch
 	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-lapi-regen.sh-Fix-s390-check.patch
 	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0002-lapi-syscalls-s390x-Fix-u-getrlimit-syscall-numbers.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-fcntl36-make-sure-write-threads-complete-at-least-1-.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-cma-fix-the-failure-of-compiling-with-O2-op.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-migrate_pages03-skip-migratition-of-shared-.patch
+
 endif
 	@# The following ones are for specific hardware/release
 ifneq (,$(filter 4 5 s390 s390x, $(OS_MAJOR_RELEASE) $(ARCH)))

--- a/distribution/ltp/include/patches/20190115/0001-fcntl36-make-sure-write-threads-complete-at-least-1-.patch
+++ b/distribution/ltp/include/patches/20190115/0001-fcntl36-make-sure-write-threads-complete-at-least-1-.patch
@@ -1,0 +1,68 @@
+From 659d4830589c0dab0d65e1f3721f2829c174c920 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 22 Feb 2019 19:44:19 +0100
+Subject: [PATCH] fcntl36: make sure write threads complete at least 1 loop
+
+A failure has been reported while this test ran on a 1 CPU KVM guest
+with 4.20 kernel:
+  ...
+  fcntl36.c:303: INFO: OFD r/w lock vs POSIX read lock
+  fcntl36.c:360: FAIL: Unexpected data offset 3072 value 1
+
+I wasn't able to reproduce it, to test the theory that
+one of write threads was given time on CPU only after
+loop_flag changed. Which means it wasn't able to complete
+a single iteration.
+
+This patch makes sure that write threads make at least
+one iteration.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Xiong Zhou <xzhou@redhat.com>
+---
+ testcases/kernel/syscalls/fcntl/fcntl36.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/fcntl/fcntl36.c b/testcases/kernel/syscalls/fcntl/fcntl36.c
+index 2942e4e6a..58a37e7bc 100644
+--- a/testcases/kernel/syscalls/fcntl/fcntl36.c
++++ b/testcases/kernel/syscalls/fcntl/fcntl36.c
+@@ -95,7 +95,7 @@ static void *fn_ofd_w(void *arg)
+ 		.l_pid    = 0,
+ 	};
+ 
+-	while (loop_flag) {
++	do {
+ 
+ 		memset(buf, wt, pa->length);
+ 
+@@ -113,7 +113,7 @@ static void *fn_ofd_w(void *arg)
+ 			wt = pa->cnt;
+ 
+ 		sched_yield();
+-	}
++	} while (loop_flag);
+ 
+ 	pthread_barrier_wait(&barrier);
+ 	SAFE_CLOSE(fd);
+@@ -134,7 +134,7 @@ static void *fn_posix_w(void *arg)
+ 		.l_len    = pa->length,
+ 	};
+ 
+-	while (loop_flag) {
++	do {
+ 
+ 		memset(buf, wt, pa->length);
+ 
+@@ -152,7 +152,7 @@ static void *fn_posix_w(void *arg)
+ 			wt = pa->cnt;
+ 
+ 		sched_yield();
+-	}
++	} while (loop_flag);
+ 
+ 	pthread_barrier_wait(&barrier);
+ 	SAFE_CLOSE(fd);
+-- 
+2.20.1
+

--- a/distribution/ltp/include/patches/20190115/0001-syscalls-cma-fix-the-failure-of-compiling-with-O2-op.patch
+++ b/distribution/ltp/include/patches/20190115/0001-syscalls-cma-fix-the-failure-of-compiling-with-O2-op.patch
@@ -1,0 +1,117 @@
+From 7591410accfcec2b91feae7f5bb7a2c8c6313a66 Mon Sep 17 00:00:00 2001
+From: Jason Xing <kerneljasonxing@linux.alibaba.com>
+Date: Tue, 26 Feb 2019 10:22:40 +0800
+Subject: [PATCH] syscalls/cma: fix the failure of compiling with O2 option
+
+This issue is triggered by the commit 9b02cd465f70 which I wrote. If
+compile the process_vm_readv03.c with O2 option and run, it will return
+TFAIL. By casting the int type to unsigned long type in the ltp_syscall
+calling functions can we avoid this failure. Thus I modify all the
+testcases which might be affected by the previous commit.
+
+[jstancek: 9b02cd465f70 removed a function that handled int->long
+promotion. glibc's syscall.S takes 6th argument from stack
+as quadword.
+  ENTRY (syscall)
+          movq %rdi, %rax         /* Syscall number -> rax.  */
+          movq %rsi, %rdi         /* shift arg1 - arg5.  */
+          movq %rdx, %rsi
+          movq %rcx, %rdx
+          movq %r8, %r10
+          movq %r9, %r8
+          movq 8(%rsp),%r9        /* arg6 is on the stack.  */
+          syscall                 /* Do the system call.  */
+If only 'int' is pushed by syscall() then the result depends on
+other stack content. If it happens to be != 0, then "flags" is
+non-zero and we get EINVAL from kernel.]
+
+Signed-off-by: Jason Xing <kerneljasonxing@linux.alibaba.com>
+Reviewed-by: Li Wang <liwang@redhat.com>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/cma/process_vm_readv02.c  | 4 ++--
+ testcases/kernel/syscalls/cma/process_vm_readv03.c  | 9 +++++----
+ testcases/kernel/syscalls/cma/process_vm_writev02.c | 4 ++--
+ 3 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/cma/process_vm_readv02.c b/testcases/kernel/syscalls/cma/process_vm_readv02.c
+index e1fc32af9..68e1bea97 100644
+--- a/testcases/kernel/syscalls/cma/process_vm_readv02.c
++++ b/testcases/kernel/syscalls/cma/process_vm_readv02.c
+@@ -135,7 +135,7 @@ static void child_invoke(void)
+ 
+ 	tst_resm(TINFO, "child 1: reading string from same memory location.");
+ 	TEST(ltp_syscall(__NR_process_vm_readv, pids[0],
+-			 &local, 1, &remote, 1, 0));
++			 &local, 1UL, &remote, 1UL, 0UL));
+ 	if (TEST_RETURN != len)
+ 		tst_brkm(TFAIL | TERRNO, tst_exit, "process_vm_readv");
+ 	if (strncmp(lp, tst_string, len) != 0)
+@@ -150,7 +150,7 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	/* Just a sanity check of the existence of syscall */
+-	ltp_syscall(__NR_process_vm_readv, getpid(), NULL, 0, NULL, 0, 0);
++	ltp_syscall(__NR_process_vm_readv, getpid(), NULL, 0UL, NULL, 0UL, 0UL);
+ 
+ 	tst_tmpdir();
+ 	TST_CHECKPOINT_INIT(cleanup);
+diff --git a/testcases/kernel/syscalls/cma/process_vm_readv03.c b/testcases/kernel/syscalls/cma/process_vm_readv03.c
+index 45f7c92e4..f09dfb0e4 100644
+--- a/testcases/kernel/syscalls/cma/process_vm_readv03.c
++++ b/testcases/kernel/syscalls/cma/process_vm_readv03.c
+@@ -181,7 +181,7 @@ static long *fetch_remote_addrs(void)
+ 	remote.iov_len = len;
+ 
+ 	TEST(ltp_syscall(__NR_process_vm_readv, pids[0], &local,
+-			 1, &remote, 1, 0));
++			 1UL, &remote, 1UL, 0UL));
+ 	if (TEST_RETURN != len)
+ 		tst_brkm(TFAIL | TERRNO, tst_exit, "process_vm_readv");
+ 
+@@ -213,8 +213,9 @@ static void child_invoke(int *bufsz_arr)
+ 	tst_resm(TINFO, "child 1: %d local iovecs initialized.",
+ 		 NUM_LOCAL_VECS);
+ 
+-	TEST(ltp_syscall(__NR_process_vm_readv, pids[0], local, NUM_LOCAL_VECS,
+-				   remote, nr_iovecs, 0));
++	TEST(ltp_syscall(__NR_process_vm_readv, pids[0], local,
++			    (unsigned long)NUM_LOCAL_VECS, remote,
++			    (unsigned long)nr_iovecs, 0UL));
+ 	if (TEST_RETURN != bufsz)
+ 		tst_brkm(TBROK | TERRNO, tst_exit, "process_vm_readv");
+ 
+@@ -248,7 +249,7 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	/* Just a sanity check of the existence of syscall */
+-	ltp_syscall(__NR_process_vm_readv, getpid(), NULL, 0, NULL, 0, 0);
++	ltp_syscall(__NR_process_vm_readv, getpid(), NULL, 0UL, NULL, 0UL, 0UL);
+ 
+ 	nr_iovecs = nflag ? SAFE_STRTOL(NULL, nr_opt, 1, IOV_MAX) : 10;
+ 	bufsz = sflag ? SAFE_STRTOL(NULL, sz_opt, NUM_LOCAL_VECS, LONG_MAX)
+diff --git a/testcases/kernel/syscalls/cma/process_vm_writev02.c b/testcases/kernel/syscalls/cma/process_vm_writev02.c
+index b1edba596..2e7a8d60b 100644
+--- a/testcases/kernel/syscalls/cma/process_vm_writev02.c
++++ b/testcases/kernel/syscalls/cma/process_vm_writev02.c
+@@ -172,7 +172,7 @@ static void child_write(void)
+ 
+ 	tst_resm(TINFO, "child 2: write to the same memory location.");
+ 	TEST(ltp_syscall(__NR_process_vm_writev, pids[0], &local,
+-			 1, &remote, 1, 0));
++			 1UL, &remote, 1UL, 0UL));
+ 	if (TEST_RETURN != bufsz)
+ 		tst_brkm(TFAIL | TERRNO, tst_exit, "process_vm_readv");
+ }
+@@ -182,7 +182,7 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	/* Just a sanity check of the existence of syscall */
+-	ltp_syscall(__NR_process_vm_writev, getpid(), NULL, 0, NULL, 0, 0);
++	ltp_syscall(__NR_process_vm_writev, getpid(), NULL, 0UL, NULL, 0UL, 0UL);
+ 
+ 	bufsz =
+ 	    sflag ? SAFE_STRTOL(NULL, sz_opt, 1, LONG_MAX - PADDING_SIZE * 2)
+-- 
+2.20.1
+

--- a/distribution/ltp/include/patches/20190115/0001-syscalls-migrate_pages03-skip-migratition-of-shared-.patch
+++ b/distribution/ltp/include/patches/20190115/0001-syscalls-migrate_pages03-skip-migratition-of-shared-.patch
@@ -1,0 +1,80 @@
+From 53eac722fd37d5601929d2354663ac071131c4a0 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 29 Nov 2018 17:29:30 +0100
+Subject: [PATCH] syscalls/migrate_pages03: skip migratition of shared pages
+
+Fixes: #431
+
+Migrating shared pages (as root) includes also executable pages
+(glibc, etc.) Kernel might need to invalidate icache, which can
+be an expensive operation on some HW (e.g. arm64 with 64k pages).
+
+This test is repeating migration thousands of times, and because
+migration (and icache flush) runs for each page, it all stacks
+up and test is hitting a timeout.
+
+It's enough for this reproducer to migrate pages it allocates
+and merges (via KSM), so do the migration as unprivileged user
+and we can avoid the overhead of migrating everything. Such
+scenario is already covered by migrate_pages02.
+
+Poor icache flush performance has been observerd only on some HW
+and reported upstream as separate issue:
+  http://lists.linux.it/pipermail/ltp/2018-December/010295.html
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Reviewed-by: Li Wang <liwang@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/migrate_pages/migrate_pages03.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/testcases/kernel/syscalls/migrate_pages/migrate_pages03.c b/testcases/kernel/syscalls/migrate_pages/migrate_pages03.c
+index ecfc55288..7317b1128 100644
+--- a/testcases/kernel/syscalls/migrate_pages/migrate_pages03.c
++++ b/testcases/kernel/syscalls/migrate_pages/migrate_pages03.c
+@@ -33,6 +33,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <stdlib.h>
++#include <pwd.h>
+ 
+ #include "tst_test.h"
+ #include "lapi/syscalls.h"
+@@ -52,6 +53,8 @@ static void *test_pages[N_PAGES];
+ static int num_nodes, max_node;
+ static int *nodes;
+ static unsigned long *new_nodes[2];
++static const char nobody_uid[] = "nobody";
++static struct passwd *ltpuser;
+ 
+ static void setup(void)
+ {
+@@ -69,6 +72,8 @@ static void setup(void)
+ 			TEST_NODES);
+ 	}
+ 
++	ltpuser = SAFE_GETPWNAM(nobody_uid);
++
+ 	max_node = LTP_ALIGN(get_max_node(), sizeof(unsigned long) * 8);
+ 	nodemask_size = max_node / 8;
+ 	new_nodes[0] = SAFE_MALLOC(nodemask_size);
+@@ -125,6 +130,7 @@ static void migrate_test(void)
+ {
+ 	int loop, i, ret;
+ 
++	SAFE_SETEUID(ltpuser->pw_uid);
+ 	for (loop = 0; loop < N_LOOPS; loop++) {
+ 		i = loop % 2;
+ 		ret = tst_syscall(__NR_migrate_pages, 0, max_node,
+@@ -134,6 +140,7 @@ static void migrate_test(void)
+ 			return;
+ 		}
+ 	}
++	SAFE_SETEUID(0);
+ 
+ 	tst_res(TPASS, "migrate_pages() passed");
+ }
+-- 
+2.20.1
+


### PR DESCRIPTION
To fix three test failures reported by CKI:
     migrate_pages03, fcntl36, process_vm_readv03

Signed-off-by: Li Wang <liwang@redhat.com>