### PR TITLE
missing objcopy command if running check-install

### DIFF
--- a/distribution/kpkginstall/Makefile
+++ b/distribution/kpkginstall/Makefile
@@ -47,4 +47,4 @@ $(METADATA): Makefile
 	@echo "License:         GPL" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Requires:        $(PACKAGE_NAME) make curl grubby tar" >> $(METADATA)
+	@echo "Requires:        $(PACKAGE_NAME) make curl grubby tar binutils" >> $(METADATA)


### PR DESCRIPTION
@veruu this is needed if we move to check-install task otherwise objcopy command isn't found