### PR TITLE
Check architecture before grabbing kernel version

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -17,10 +17,10 @@ function get_kpkg_ver()
     REPO_NAME=${KPKG_URL/\//-}
     # Do the same thing as with normal repos since that's what it is and we
     # know the name now
-    ${YUM} -q --disablerepo="*" --enablerepo="${REPO_NAME}" list "${AVAILABLE}" kernel --showduplicates | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
+    ${YUM} -q --disablerepo="*" --enablerepo="${REPO_NAME}" list "${AVAILABLE}" kernel --showduplicates | grep $ARCH | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
   else
     # Grab the kernel version from the provided repo directly
-    ${YUM} -q --disablerepo="*" --enablerepo="kernel-cki" list "${AVAILABLE}" kernel --showduplicates | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
+    ${YUM} -q --disablerepo="*" --enablerepo="kernel-cki" list "${AVAILABLE}" kernel --showduplicates | grep $ARCH | awk -v arch="$ARCH" '/kernel-cki/ {print $2"."arch}'
   fi
 }
 


### PR DESCRIPTION
We have COPR repos containing both kernel.ARCH and kernel.src so we get
double output here which we really don't want.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>