### PR TITLE
kdump: enable sysrq operations

### DIFF
--- a/kdump/include/runtest.sh
+++ b/kdump/include/runtest.sh
@@ -465,6 +465,7 @@ TriggerSysrqPanic()
     PrepareReboot
 
     Log "- Triggering crash."
+    echo 1 > /proc/sys/kernel/sysrq
     echo c > /proc/sysrq-trigger
 
     sleep 60


### PR DESCRIPTION
Make the test compatible with fedora kernel.
Sysrq operations have to be enabled on fedora kernel in order to trigger sysrq-c panic.

Signed-off-by: xiawu <xiawu@redhat.com>