### PR TITLE
perf: adding internal-testsuite wrapper for CKI

### DIFF
--- a/packages/perf/internal-testsuite/Makefile
+++ b/packages/perf/internal-testsuite/Makefile
@@ -1,0 +1,65 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /tools/perf/Regression/internal-testsuite-cki
+#   Description: internal-testsuite
+#   Author: Michael Petlan <mpetlan@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2014 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/tools/perf/Regression/internal-testsuite-cki
+export TESTVERSION=2.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE white.list
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Michael Petlan <mpetlan@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     internal-testsuite" >> $(METADATA)
+	@echo "Type:            Regression" >> $(METADATA)
+	@echo "TestTime:        30m" >> $(METADATA)
+	@echo "RunFor:          perf" >> $(METADATA)
+	@echo "Requires:        perf perf-debuginfo" >> $(METADATA)
+	@echo "Requires:        python-perf python3-perf" >> $(METADATA)
+	@echo "Requires:        kernel-debuginfo iputils-debuginfo" >> $(METADATA)
+	@echo "Requires:        yum-utils dnf-utils" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2+" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/packages/perf/internal-testsuite/PURPOSE
+++ b/packages/perf/internal-testsuite/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /tools/perf/Regression/internal-testsuite-cki
+Description: internal-testsuite for CKI
+Author: Michael Petlan <mpetlan@redhat.com>

--- a/packages/perf/internal-testsuite/runtest.sh
+++ b/packages/perf/internal-testsuite/runtest.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /tools/perf/Regression/internal-testsuite-cki
+#   Description: internal-testsuite
+#   Author: Michael Petlan <mpetlan@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2014 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="perf"
+
+# configuration
+PERFTESTS_ENABLE_BLACKLIST=${PERFTESTS_ENABLE_BLACKLIST:-0}
+
+# hook, someone likes using "True" there, we like 1, 0 values more
+if [ "$PERFTESTS_ENABLE_BLACKLIST" = "true" -o "$PERFTESTS_ENABLE_BLACKLIST" = "True" ]; then
+	PERFTESTS_ENABLE_BLACKLIST=1
+fi
+
+check_whitelisted()
+{
+	HASH=`echo -n "$1" | sha1sum | awk '{print $1}'`
+	cat white.list | perl -pe 's/#.*$//' | grep $HASH | grep -q -e "all" -e "$ARCH"
+	return $?
+}
+
+prepare_whitelists()
+{
+	rlRun "cp white.list $TmpDir/" 0 "WHITELIST: adding basic whitelist"
+}
+
+rlJournalStart
+	rlPhaseStartSetup
+		rlAssertRpm $PACKAGE
+		rlCheckRpm python-perf || yum -y install python-perf
+		export ARCH=`arch`
+		export KERNEL=`uname -r`
+
+		export KERNEL_PKG_NAME="kernel-$KERNEL"
+		export KERNEL_DEBUGINFO_PKG_NAME="kernel-debuginfo-$KERNEL"
+		echo $KERNEL | grep -q debug
+		if [ $? -eq 0 ]; then
+			export KERNEL=${KERNEL%[.+]debug}
+			export KERNEL_PKG_NAME="kernel-debug-$KERNEL"
+			export KERNEL_DEBUGINFO_PKG_NAME="kernel-debug-debuginfo-$KERNEL"
+		fi
+		rlLog "Variables:"
+		rlLog "KERNEL = $KERNEL"
+		rlLog "KERNEL_PKG_NAME = $KERNEL_PKG_NAME"
+		rlLog "KERNEL_DEBUGINFO_PKG_NAME = $KERNEL_DEBUGINFO_PKG_NAME"
+		rpmquery $KERNEL_DEBUGINFO_PKG_NAME
+		if [ $? -ne 0 ]; then
+			# we need to install debuginfo for the proper kernel
+			# but sometimes, debuginfo-install is not available!
+			which debuginfo-install || rlRun "yum -y install yum-utils dnf-utils" 0 "Installing {yum,dnf}-utils (it has not been present)"
+			which debuginfo-install # now it should be installed, but what if it fails...
+			if [ $? -eq 0 ]; then
+				rlRun "debuginfo-install -y $KERNEL_PKG_NAME" 0 "Installing debuginfo for $KERNEL_PKG_NAME via debuginfo-install (it has not been present)"
+			else
+				rlRun "yum install -y $KERNEL_DEBUGINFO_PKG_NAME" 0 "Installing debuginfo for $KERNEL_PKG_NAME via yum/dnf (unable to obtain debuginfo-install)"
+			fi
+		fi
+		rlRun "rpmquery $KERNEL_DEBUGINFO_PKG_NAME" 0 "Correct debuginfo is installed ($KERNEL)"
+		echo "==================== kernel packages installed ===================="
+		rpmquery -a | grep -e kernel -e perf
+		echo "==================================================================="
+		rlCheckRpm $PACKAGE-debuginfo || rlRun "debuginfo-install -y $PACKAGE"
+		rlAssertRpm $PACKAGE-debuginfo
+		# we need iputils-debuginfo for the sake of `perf test inet_pton` testcase
+		rlCheckRpm iputils-debuginfo || rlRun "debuginfo-install -y iputils"
+		rlAssertRpm iputils-debuginfo
+
+		mkdir TMP ; cd TMP
+		export TmpDir=`pwd`
+		cd ..
+
+		# PREPARE WHITELISTS
+		prepare_whitelists
+
+		# This is important: remember the original sample rate to be restored later
+		#
+		# Various heavy tests may lead to that kernel throttles the sample rate too much
+		# which may cause other tests to fail and such failures look mysterious and are
+		# hard to investigate and reproduce. This should harden the test to be less prone
+		# to this type of problems.
+		ORIGINAL_SAMPLE_RATE=`sysctl kernel.perf_event_max_sample_rate | tr -d ' ' | cut -d= -f2`
+		echo "ORIGINAL SAMPLE RATE = $ORIGINAL_SAMPLE_RATE" | tee -a ${OUTPUTFILE}
+		REASONABLE_SAMPLE_RATE=20000
+		if [ $ORIGINAL_SAMPLE_RATE -lt $REASONABLE_SAMPLE_RATE ]; then
+			echo "(it seems to be too low, so increasing it to $REASONABLE_SAMPLE_RATE" | tee -a ${OUTPUTFILE}
+			ORIGINAL_SAMPLE_RATE=$REASONABLE_SAMPLE_RATE
+		fi
+
+		rlRun "pushd $TmpDir >/dev/null"
+		rlRun "perf test list |& tee tests.list" 0 "We will run the following tests:"
+	rlPhaseEnd
+
+	while read line; do
+		TEST_NUMBER="`echo $line | perl -ne 'print $1 if /^(\d+):\s/'`"
+		TEST_DESC="`echo $line | perl -pe 's/^\d+:\s//'`"
+		# skip the incompatible lines (basically the subtests)
+		test -n "$TEST_NUMBER" || continue
+		rlPhaseStart FAIL "TEST #$TEST_NUMBER : $TEST_DESC"
+			if check_whitelisted "$TEST_DESC"; then
+				rlLog "[ WHITELISTED ] :: $TEST_NUMBER: $TEST_DESC  (known issue)"
+			else
+				perf test -vv $TEST_NUMBER |& tee $TEST_NUMBER.log
+				RETVAL=$?
+				RESULT=`tail -n 1 $TEST_NUMBER.log | awk -F':' '{print $NF}' | tr -d ' '`
+				printf "%8s -- %s\n" $RESULT "$line" | tee -a results.log
+				echo $RESULT | grep -qi FAIL
+				if [ $RETVAL -ne 0 -o $? -eq 0 ]; then
+					rlFail "$TEST_NUMBER: $TEST_DESC"
+				else
+					rlPass "$TEST_NUMBER: $TEST_DESC"
+				fi
+
+				# restore original sample rate to ensure the tests dependent on it pass
+				# more info: https://bugzilla.redhat.com/show_bug.cgi?id=1532741#c18
+				sysctl kernel.perf_event_max_sample_rate=$ORIGINAL_SAMPLE_RATE
+			fi
+		rlPhaseEnd
+	done < tests.list
+
+	# bz1414043 coverage
+	rlPhaseStartTest "bz1414043 coverage -- \"Session topology\" test fails with some CPUs disabled"
+		# check if we have enough CPUs (at least two)
+		if [ `nproc` -lt 2 ]; then
+			rlLog "bz1414043 coverage skipped (we need at least 2 cpus)"
+		else
+			# check if the test is not disabled on this machine
+			TEST_NUMBER="`perf test list |& grep topology | perl -ne 'print $1 if /^(\d+):\s/'`"
+			TEST_DESC="`perf test list |& grep topology | perl -pe 's/^\d+:\s//'`"
+			if check_whitelisted "$TEST_DESC" || check_whitelisted "Session topology with CPU disabled"; then
+				rlLog "bz1414043 coverage skipped (whitelisted)"
+			else
+				# check if we can disable a cpu (we sometimes cannot on aarch64)
+				echo 0 > /sys/devices/system/cpu/cpu1/online
+				if [ $? -ne 0 ]; then
+					rlLog "bz1414043 coverage skipped (cannot turn cpu1 off)"
+				else
+					# now it should be OK, so test!
+					rlRun "perf test -v topology" 0 "bz1414043 test (should PASS)" # BUG REPRODUCTION ASSERT
+					rlRun "echo 1 > /sys/devices/system/cpu/cpu1/online" 0 "Turning the cpu1 back on"
+				fi
+			fi
+		fi
+	rlPhaseEnd
+
+	# this test is suitable for kernels version 3 and newer
+	KERNEL_MAJOR_VERSION=`uname -r | perl -ne 'print "$1" if /^(\d+)\./'`
+	if [ $KERNEL_MAJOR_VERSION -ge 3 ]; then
+	# bz1308907 coverage
+	rlPhaseStartTest "bz1308907 coverage -- FAILED '/usr/libexec/perf-core/tests/attr/test-stat-C0' - match failure"
+		# check if the test is not disabled on this machine
+		TEST_NUMBER="`perf test list |& grep perf_event_attr | perl -ne 'print $1 if /^(\d+):\s/'`"
+		TEST_DESC="`perf test list |& grep perf_event_attr | perl -pe 's/^\d+:\s//'`"
+		if check_whitelisted "$TEST_DESC"; then
+			rlLog "bz1308907 coverage skipped (whitelisted)"
+		else
+			# the corresponding perf-test should NOT contain the following line in the output:
+			# FAILED '/usr/libexec/perf-core/tests/attr/test-stat-C0' - match failure
+			rlRun "perf test -v $TEST_NUMBER |& grep FAILED" 1 "bz1308907 test (should PASS)" # BUG REPRODUCTION ASSERT
+		fi
+	rlPhaseEnd
+	fi
+
+	rlPhaseStartCleanup
+		rlRun "tar c * | xz > logs-`date +%s`.tar.xz"
+		rlFileSubmit "logs-*.tar.xz"
+		echo "===========================[ results ]============================="
+		cat results.log
+		echo "==================================================================="
+		rlRun -l "cat results.log | grep FAILED" 1 "No tests failed"
+		rlRun "popd >/dev/null"
+		rlRun "rm -rf $TmpDir"
+		# restore the sample rate back to the original or something reasonable
+		sysctl kernel.perf_event_max_sample_rate=$ORIGINAL_SAMPLE_RATE
+	rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/packages/perf/internal-testsuite/white.list
+++ b/packages/perf/internal-testsuite/white.list
@@ -46,7 +46,7 @@ aba5be59b8476eb15178828406fa0d307fb794b9 aarch64 s390x x86_64 ppc64le # Test dwa
 30d384952b664d5c4f5b81753b0edffc0b003695 x86_64 # x86 rdpmc
 24a8cd476d3077c41e5795428ea7820d88d12309 x86_64 # Convert perf time to TSC
 
-# Known ppc64le bugs
-9e14b86f572e9d058f59302cfa8759e5afb20017 ppc64le # probe libc's inet_pton & backtrace it with ping
+# Known bugs
+9e14b86f572e9d058f59302cfa8759e5afb20017 ppc64le aarch64 x86_64 # probe libc's inet_pton & backtrace it with ping
 90ae3743ecb512bf3d9956df1d6ea8cbb3f63dc6 ppc64le # Use vfs_getname probe to get syscall args filenames
 0e5b27841d80bf495ebfbfb1a446f7ca08fe5e97 ppc64le # Check open filename arg using perf trace + vfs_getname

--- a/packages/perf/internal-testsuite/white.list
+++ b/packages/perf/internal-testsuite/white.list
@@ -1,0 +1,47 @@
+# FORMAT:
+#   sha1sum arch1 arch2 arch3  # comment (test name)
+#
+# where archs might be also "all"
+#
+#  testcases listed here will be skipped
+#  everything from the '#' sign to the end of line is ignored
+
+#### s390x does not have syscall tracepoints, only raw syscalls
+04a274b4bcd3b75f2c514964b7782c836864d631 s390x	# Detect openat syscall event
+8d735cfd56f7d85dc83eba589af9ec15736f5b1a s390x  # Detect openat syscall event on all cpus
+2b05df303eaa71ff64f21a705a2232428d79cf41 s390x  # Detect open syscall event
+e2b405038028fad78e4b440fee4615c9e3105437 s390x	# Detect open syscall event on all cpus
+c40b1c8154d00b7e0a191e18721a2310236f1ca9 s390x	# syscalls:sys_enter_openat event fields
+6a42a33ddab2bb2e5f06c68dae1f01317f2d3687 s390x	# syscalls:sys_enter_open event fields
+dc25abc10dbbe8bbcfd828943e562325bb04d11d s390x	# Read samples using the mmap interface
+
+### s390x does not have cycles and 'dummy' event is not on RHEL6
+1452f6a9560857ae31acc9eaad816ae63c0cec44 s390x	# PERF_RECORD_* events & perf_sample fields
+
+#### tests that should be skipped, if it is not, we have to do it ourselves
+b81906564501bbdb29b976760f7e3735760c3d05 s390x	# Number of exit events of a simple workload
+
+#### to be investigated
+3370c451caa40aa5cb102f145c75eb22141766eb x86_64	# DWARF unwind
+
+#### fails on s390x due to events we don't need at RH
+a314df14af58957548d292f859cbd2ee451c9c9f s390x	# Parse event definition strings
+8d036401505f5579ff5912c30cbccb3c5098d8cd s390x	# Object code reading
+
+#### this test currently fails on powerpc, known thing
+64b224a2fb478a47529700c6237c6c0a0a90ad98 ppc64le ppc64	# Session topology
+
+#### this should be blacklisted on all non-x86_64, it goes slowly, so blacklisting here
+#    (bz1432652 fixes s390x only, not aarch64...)
+b549be0430aa3df45cf25675e2cad1b50d710435 aarch64 s390x # Breakpoint overflow signal handler
+4a3f54aad1d4f9f5a613f72c20a12273533f438f aarch64 s390x # Breakpoint overflow sampling
+
+#### GENERALLY UNSTABLE ####
+
+8d036401505f5579ff5912c30cbccb3c5098d8cd aarch64 s390x x86_64 ppc64le # Object code reading
+3370c451caa40aa5cb102f145c75eb22141766eb aarch64 s390x x86_64 ppc64le # DWARF unwind
+aba5be59b8476eb15178828406fa0d307fb794b9 aarch64 s390x x86_64 ppc64le # Test dwarf unwind
+
+#### PMU might not work on KVM guests
+30d384952b664d5c4f5b81753b0edffc0b003695 x86_64 # x86 rdpmc
+24a8cd476d3077c41e5795428ea7820d88d12309 x86_64 # Convert perf time to TSC

--- a/packages/perf/internal-testsuite/white.list
+++ b/packages/perf/internal-testsuite/white.list
@@ -45,3 +45,8 @@ aba5be59b8476eb15178828406fa0d307fb794b9 aarch64 s390x x86_64 ppc64le # Test dwa
 #### PMU might not work on KVM guests
 30d384952b664d5c4f5b81753b0edffc0b003695 x86_64 # x86 rdpmc
 24a8cd476d3077c41e5795428ea7820d88d12309 x86_64 # Convert perf time to TSC
+
+# Known ppc64le bugs
+9e14b86f572e9d058f59302cfa8759e5afb20017 ppc64le # probe libc's inet_pton & backtrace it with ping
+90ae3743ecb512bf3d9956df1d6ea8cbb3f63dc6 ppc64le # Use vfs_getname probe to get syscall args filenames
+0e5b27841d80bf495ebfbfb1a446f7ca08fe5e97 ppc64le # Check open filename arg using perf trace + vfs_getname


### PR DESCRIPTION
This is a wrapper for perf-test which whitelists some known failures
and unstable tests for the sake of having it stable and passing.