### PR TITLE
ltp/include: enlarge skipping range for mount02

### DIFF
--- a/distribution/ltp/include/knownissue.sh
+++ b/distribution/ltp/include/knownissue.sh
@@ -138,7 +138,7 @@ function knownissue_filter()
 		# http://lists.linux.it/pipermail/ltp/2017-January/003424.html
 		kernel_in_range "4.8.0-rc6" "4.12" && tskip "utimensat01.*" unfix
 		# http://lists.linux.it/pipermail/ltp/2019-March/011231.html
-		kernel_in_range "5.0.0" "5.1.0" && tskip "mount02" unfix
+		kernel_in_range "5.0.0" "5.2.0" && tskip "mount02" unfix
 	fi
 
 	if is_rhel8; then


### PR DESCRIPTION
The suffix of kernel version haven't being handled in the kvercmp() funcion,
so we get wrong result in compare the 5.1.0 with 5.1.0-rc2.cki leads to ltp
cann't mask mount02 failure correctly.

In this patch, I just exlarge the RC kernel version to 5.2.0 to make the filter
goes into effect.

Signed-off-by: Li Wang <liwang@redhat.com>