### PR TITLE
stress/stress-ng: abort if a reboot is detected

### DIFF
--- a/stress/stress-ng/runtest.sh
+++ b/stress/stress-ng/runtest.sh
@@ -110,6 +110,11 @@ esac
 EXCLUDE=$(sed -e 's/^,//' -e 's/,$//' <<<$EXCLUDE)
 
 rlPhaseStartSetup
+    # if stress-ng triggers a panic and reboot, then abort the test
+    if [ $REBOOTCOUNT -ge 1 ] ; then
+        rlDie "Aborting due to system crash and reboot"
+    fi
+
     rlLog "Downloading stress-ng from source"
     rlRun "git clone $GIT_URL" 0
     if [ $? != 0 ]; then


### PR DESCRIPTION
If a stressor causes a kernel panic and reboot, then abort the test
run.  Do not try to start the test again or it will likely get into
a panic-and-reboot-loop until the external watchdog kills it.