### PR TITLE
stress-ng: add sigsuspend to known issues list

### DIFF
--- a/stress/stress-ng/runtest.sh
+++ b/stress/stress-ng/runtest.sh
@@ -62,6 +62,8 @@ EXCLUDE+=",bad-altstack,opcode"
 # fanotify fails on systems with many CPUs (>128?):
 #     cannot initialize fanotify, errno=24 (Too many open files)
 EXCLUDE+=",fanotify"
+# sigsuspend often triggers slow path warnings until killed by the watchdog
+EXCLUDE+=",sigsuspend"
 
 ARCH=`uname -m`
 # RHEL specific excludes


### PR DESCRIPTION
The `sigsuspend` stressor often locks up systems and the kernel just logs slow path WARNINGs until the test is killed by the watchdog, so add it to the known issues list and skip it.