### PR TITLE
ltp/include: treat ARK kernel as upstream too

### DIFF
--- a/distribution/ltp/include/knownissue.sh
+++ b/distribution/ltp/include/knownissue.sh
@@ -58,7 +58,7 @@ function is_rhel6() { grep -q "release 6" /etc/redhat-release; }
 function is_rhel7() { grep -q "release 7" /etc/redhat-release; }
 function is_rhel8() { grep -q "release 8" /etc/redhat-release; }
 function is_rhel_alt() { rpm -q --qf "%{sourcerpm}\n" -f /boot/vmlinuz-$(uname -r) | grep -q "alt"; }
-function is_upstream() { uname -r | grep -q -v 'el\|fc'; }
+function is_upstream() { uname -r | grep -q -v 'el[0-9]\|fc'; }
 function is_arch() { [ "$(uname -m)" == "$1" ]; }
 # osver_low <= $osver < osver_high
 function osver_in_range() { [ "$1" -le "$osver" -a "$osver" -lt "$2" ]; }


### PR DESCRIPTION
The function is_upstream() { uname -r | grep -q -v 'el\|fc'; } has problem
to recongise ARK kernel, since CKI build that with suffix *.elrdy.*, here
we just treat it same as upstream kernel.

Signed-off-by: Li Wang <liwang@redhat.com>