### PR TITLE
update selinux to latest downstream version

### DIFF
--- a/packages/selinux-policy/serge-testsuite/Makefile
+++ b/packages/selinux-policy/serge-testsuite/Makefile
@@ -55,7 +55,7 @@ $(METADATA): Makefile
 	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "RunFor:          selinux-policy" >> $(METADATA)
 	@echo "Requires:        /usr/bin/unbuffer" >> $(METADATA)
-	@echo "Requires:        checkpolicy libselinux-devel libsepol-devel net-tools policycoreutils-devel selinux-policy selinux-policy-devel git perl-Test-Harness gcc netlabel_tools ipsec-tools perl-Test perl-Test-Simple perl-Test-Harness attr rdma-core-devel libibverbs-devel nmap-ncat nc secilc libsemanage expect lksctp-tools-devel kernel-modules-extra platform-python python3" >> $(METADATA)
+	@echo "Requires:        checkpolicy libselinux-devel libsepol-devel net-tools policycoreutils-devel selinux-policy selinux-policy-devel git perl-Test-Harness gcc netlabel_tools ipsec-tools perl-Test perl-Test-Simple perl-Test-Harness attr rdma-core-devel libibverbs-devel nmap-ncat nc secilc libsemanage expect lksctp-tools-devel kernel-modules-extra kernel-rt-modules-extra platform-python python3" >> $(METADATA)
 	@echo "RhtsRequires:    library(selinux-policy/common)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)


### PR DESCRIPTION
@veruu this will sync the downstream version with upstream, and allow us to re-enable on s390x & aarch64 on RHEL-8, will test more thoroughly in kpet-db