### PR TITLE
ltp/include: disable distro exclusion in upstream kernel testing

### DIFF
--- a/distribution/ltp/include/knownissue.sh
+++ b/distribution/ltp/include/knownissue.sh
@@ -21,6 +21,14 @@
 #          suggest to skip it when <= unfix-rhel-version, or we can remark
 #          the test result as KNOWN issue to avoid beaker report failure.
 #
+# Issue Note:
+#      We'd better follow these principles to exlucde testcase:
+#      1. Upstream kernel bug use its kernel-nvr ranges
+#      2. RHEL kernel bug(fixed) use its kernel-nvr ranges
+#      3. RHEL kernel bug(unfix) use distro exclustion first, then move
+#         to kernel-nvr ranges once it has been fixed.
+#      4. Userspace package bug use itself package-nvr ranges
+#
 # Added-by: Li Wang <liwang@redhat.com>
 
 . ../include/kvercmp.sh  || exit 1
@@ -61,7 +69,7 @@ function is_rhel_alt() { rpm -q --qf "%{sourcerpm}\n" -f /boot/vmlinuz-$(uname -
 function is_upstream() { uname -r | grep -q -v 'el[0-9]\|fc'; }
 function is_arch() { [ "$(uname -m)" == "$1" ]; }
 # osver_low <= $osver < osver_high
-function osver_in_range() { [ "$1" -le "$osver" -a "$osver" -lt "$2" ]; }
+function osver_in_range() { ! is_upstream && [ "$1" -le "$osver" -a "$osver" -lt "$2" ]; }
 
 # kernel_low <= $cver < kernel_high
 function kernel_in_range()


### PR DESCRIPTION
As Veronika pointed that the distro exclusion cann't work properly in
upstream kernel testing on RHEL. Becasue sometimes a RHEL kernel bug
maybe has already been fixed in upstream, the distro exclusion still
trying to kick-out it as a known issue.

To solve that we could simply try to detect whether a distro installs the
upstream kernel, if yes, we just give up the filtering rule at this case.
It will be eventually separate the upstream and downstream. Problem could
be located in any part of these: [UPSTREAM] [RHEL8] [RHEL7] [RHEL6] [RHEL5]
Btw, the [UPSTREAM] part includes: CKI, ARK and Mainline kernel.

Note:
  osver_in_range is just as workaround for unfix knownissue filtering, once
  an unfix problem is being fixed there, we should move it to fixed issue
  part and change the rule from distro exclusion to kernel NVR comparing.

So, we'd better follow these principles to exlucde testcase in future:
  1. Upstream kernel bug use its kernel-nvr ranges
  2. RHEL kernel bug(fixed) use its kernel-nvr ranges
  3. RHEL kernel bug(unfix) use distro exclustion first, then move to
     kernel-nvr ranges once it has been fixed.
  4. Userspace package bug use itself package-nvr ranges

Signed-off-by: Li Wang <liwang@redhat.com>
Acked-by: Jan Stancek <jstancek@redhat.com>