### PR TITLE
stress-ng: skip the test on Mustang systems

### DIFF
--- a/stress/stress-ng/Makefile
+++ b/stress/stress-ng/Makefile
@@ -61,6 +61,7 @@ $(METADATA):
 	@echo "Requires:	kernel-headers"				>> $(METADATA)
 	@echo "Requires:	gcc"					>> $(METADATA)
 	@echo "Requires:	wget"					>> $(METADATA)
+	@echo "Requires:	dmidecode"				>> $(METADATA)
 	@echo "Requires:	libaio-devel"				>> $(METADATA)
 	@echo "Requires:	libattr-devel"				>> $(METADATA)
 	@echo "Requires:	libbsd-devel"				>> $(METADATA)

--- a/stress/stress-ng/runtest.sh
+++ b/stress/stress-ng/runtest.sh
@@ -29,6 +29,14 @@
 . /usr/bin/rhts-environment.sh || exit 1
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+# Mustangs have a hardware flaw which causes kernel warnings under stress:
+#    list_add corruption. prev->next should be next
+if type -p dmidecode >/dev/null ; then
+    if dmidecode -t1 | grep -q 'Product Name:.*Mustang.*' ; then
+        rhts-report-result $TEST SKIP $OUTPUTFILE
+        exit
+    fi
+fi
 
 rlJournalStart
 


### PR DESCRIPTION
Mustangs have a hardware flaw exposed by stress tests such as stress-ng.  Skip the test if the SUT is a Mustang.