### PR TITLE
[storage/hba]  add FIO stress tests for HBA regression

### DIFF
--- a/storage/hba/san-device-stress/Makefile
+++ b/storage/hba/san-device-stress/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The toplevel namespace within which the test lives.
+TOPLEVEL_NAMESPACE=tests-beaker
+
+# The name of the package under test:
+PACKAGE_NAME=storage
+#
+# The path of the test below the package:
+RELATIVE_PATH=hba
+#
+# Version of the Test. Used with make tag.
+export TESTVERSION=0.1
+#
+# The combined namespace of the test.
+export TEST=/$(TOPLEVEL_NAMESPACE)/$(PACKAGE_NAME)/$(RELATIVE_PATH)
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh main.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	chmod a+x ./runtest.sh
+	chmod a+x ./main.sh
+clean:
+	rm -f *~ *.rpm $(BUILT_FILES)
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Marco Patalano <mpatalan@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     This test will generate I/O using FIO at the device level." >> $(METADATA)
+	@echo "License:		GPL v3" >> $(METADATA)
+	@echo "TestTime:	1h" >> $(METADATA)
+	@echo "RunFor:		$(PACKAGE_NAME)" >> $(METADATA)
+	@echo "Requires:        python2-lxml" >> $(METADATA)
+	@echo "Requires:        python3-lxml" >> $(METADATA)
+	@echo "Requires:        fio" >> $(METADATA)
+	@echo "Requires:        libaio-devel" >> $(METADATA)
+	@echo "Requires:        zlib-devel" >> $(METADATA)
+	@echo "Requires:        gcc" >> $(METADATA)
+	@echo "RhtsRequires:	hba" >> $(METADATA)
+
+	rhts-lint $(METADATA)
+

--- a/storage/hba/san-device-stress/PURPOSE
+++ b/storage/hba/san-device-stress/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /tests-beaker/storage/hba 
+Description: This test generates I/O with FIO at the device level using 4 different methods: write, read, randwrite, randread.
+

--- a/storage/hba/san-device-stress/README.md
+++ b/storage/hba/san-device-stress/README.md
@@ -1,0 +1,11 @@
+# san-device-stress
+FIO stress test on san device. \
+Test Maintainer: [Marco Patalano](mailto:mpatalan@redhat.com ) 
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'.
+
+### Execute the test
+```bash
+$ make run
+```

--- a/storage/hba/san-device-stress/main.sh
+++ b/storage/hba/san-device-stress/main.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+dbg_flag=${dbg_flag:-"set +x"}
+$dbg_flag
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+function fio_device_level_test() {
+        EX_USAGE=64 # Bad arg format
+        if [ $# -lt 1 ]; then
+                echo 'Usage: fio_device_level_test $test_dev'
+                exit "${EX_USAGE}"
+        fi
+        # variable definitions
+        local ret=0
+        local tmp_dev=$1
+        local runtime=180
+        local numjobs=60
+        if [ "${tmp_dev:0:5}" = "/dev/" ]; then
+                test_dev=$tmp_dev
+        else
+                test_dev="/dev/${tmp_dev}"
+
+        fi
+        rlLog "INFO: Executing fio_device_level_test() with device: $test_dev"
+
+        #fio testing
+        rlRun "fio -filename=$test_dev -iodepth=1 -thread -rw=write -ioengine=psync -bssplit=5k/10:9k/10:13k/10:17k/10:21k/10:25k/10:29k/10:33k/10:37k/10:41k/10 -direct=1 -runtime=$runtime -size=-group_reporting -name=mytest -numjobs=$numjobs"
+        if [ $? -ne 0 ]; then
+                rlLog "FAIL: fio device level write testing for $test_dev failed"
+                ret=1
+        fi
+        rlRun "fio -filename=$test_dev -iodepth=1 -thread -rw=randwrite -ioengine=psync -bssplit=5k/10:9k/10:13k/10:17k/10:21k/10:25k/10:29k/10:33k/10:37k/10:41k/10 -direct=1 -runtime=$runtime -size=-group_reporting -name=mytest -numjobs=$numjobs"
+        if [ $? -ne 0 ]; then
+                rlLog "FAIL: fio device level randwrite testing for $test_dev failed"
+                ret=1
+        fi
+        rlRun "fio -filename=$test_dev -iodepth=1 -thread -rw=read -ioengine=psync -bssplit=5k/10:9k/10:13k/10:17k/10:21k/10:25k/10:29k/10:33k/10:37k/10:41k/10 -direct=1 -runtime=$runtime -size=-group_reporting -name=mytest -numjobs=$numjobs"
+        if [ $? -ne 0 ]; then
+                rlLog "FAIL: fio device level read testing for $test_dev failed"
+                ret=1
+        fi
+        rlRun "fio -filename=$test_dev -iodepth=1 -thread -rw=randread -ioengine=psync -bssplit=5k/10:9k/10:13k/10:17k/10:21k/10:25k/10:29k/10:33k/10:37k/10:41k/10 -direct=1 -runtime=$runtime -size=-group_reporting -name=mytest -numjobs=$numjobs"
+        if [ $? -ne 0 ]; then
+                rlLog "FAIL: fio device level randread testing for $test_dev failed"
+                ret=1
+        fi
+
+        return $ret
+}
+
+
+#Find a suitable disk to run FIO
+boot_disk=$(lsblk |grep boot | awk '{print $1}' | grep -oE [a-Z]{3\,})
+for i in $(lsblk |grep disk | awk '{print $1}');do
+    if [ $i == $boot_disk ];then
+        continue
+    else
+        sd=$i
+        break
+   fi
+done
+
+if [ ! $sd ];then
+    rlLog "no free disk available" | tee -a $OUTPUTFILE
+    rhts-report-result $TEST SKIP $OUTPUTFILE
+    exit 0
+fi
+
+
+device="/dev/${sd}"
+
+
+
+rlJournalStart
+    rlPhaseStartTest
+        fio_device_level_test "$device"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/storage/hba/san-device-stress/runtest.sh
+++ b/storage/hba/san-device-stress/runtest.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+#   Author: Marco Patalano <mpatalan@redhat.com>
+
+rhts-run-simple-test hba "./main.sh"


### PR DESCRIPTION
a pattern the hba test should be triggered:  
kpet should identify any patches posted to drivers/scsi/lpfc should initiate lpfc testing.  Similarly any patches posted to drivers/scsi/qla2xxx should initiate qla2xxx testing.

Updates to the scsi directory should initiate testing on all scsi
hardware and adapters.

Updates to fc-transport should initiate testing on lpfc and qla2xxx
adapters.

Updates to iscsi infrastructure should initiate testing on iscsi initiators.

Target and other drivers have similar requirements.
