### PR TITLE
disable mtest06 for ltp-lite upstream kernels

### DIFF
--- a/distribution/ltp/include/knownissue.sh
+++ b/distribution/ltp/include/knownissue.sh
@@ -147,6 +147,8 @@ function knownissue_filter()
 		kernel_in_range "4.8.0-rc6" "4.12" && tskip "utimensat01.*" unfix
 		# http://lists.linux.it/pipermail/ltp/2019-March/011231.html
 		kernel_in_range "5.0.0" "5.2.0" && tskip "mount02" unfix
+		# https://lore.kernel.org/linux-mm/1817839533.20996552.1557065445233.JavaMail.zimbra@redhat.com/T/#u
+		kernel_in_range "5.0.0" "5.2.0" && is_arch "aarch64" && tskip "mtest06" unfix
 	fi
 
 	if is_rhel8; then


### PR DESCRIPTION
This will mask the mtest06 on aarch64, see the following for more details:
- https://github.com/linux-test-project/ltp/issues/528
- https://lore.kernel.org/linux-mm/1817839533.20996552.155706544523