### PR TITLE
set metadata test duration to match Makefile

### DIFF
--- a/distribution/ltp/lite/metadata
+++ b/distribution/ltp/lite/metadata
@@ -8,7 +8,7 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=300m
+max_time=180m
 dependencies=automake;autoconf;procmail;flex;bison;rsyslog;util-linux;rpm-build;gcc;wget;kernel-headers;redhat-lsb;bc;kernel-devel;libaio-devel;libcap-devel;libcgroup;strace
 softDependencies=numactl;numactl-devel;redhat-lsb;ntpdate;chrony
 repoRequires=distribution/ltp/include


### PR DESCRIPTION
@veruu this is related to https://github.com/CKI-project/tests-beaker/issues/158, although it will be enforced overall by kpet, these files should still be in sync.