### PR TITLE
mask shmctl01 for usptream kernels until resolved

### DIFF
--- a/distribution/ltp/include/knownissue.sh
+++ b/distribution/ltp/include/knownissue.sh
@@ -149,6 +149,8 @@ function knownissue_filter()
 		kernel_in_range "5.0.0" "5.2.0" && tskip "mount02" unfix
 		# https://lore.kernel.org/linux-mm/1817839533.20996552.1557065445233.JavaMail.zimbra@redhat.com/T/#u
 		kernel_in_range "5.0.0" "5.2.0" && is_arch "aarch64" && tskip "mtest06" unfix
+		# http://lists.linux.it/pipermail/ltp/2019-May/011989.html
+		kernel_in_range "5.0.0" "5.2.0" && tskip "shmctl01" unfix
 	fi
 
 	if is_rhel8; then


### PR DESCRIPTION
@veruu this will mask the ltp failure we are seeing for upstream kernels, we can re-enable once resolved in the ML.