### PR TITLE
legacy: pci id test changes

### DIFF
--- a/legacy/pci_id/02-pci-id.sh
+++ b/legacy/pci_id/02-pci-id.sh
@@ -94,7 +94,7 @@ function main()
         rpm_extract_add "kernel-modules-extra"
         rpm_extract
 
-        local new_kernel_dir="$(find /lib/ -type d -name "$(uname -r)")"
+        local new_kernel_dir="$(find /lib/modules/ -type d -name "$(uname -r)")"
         local old_kernel_dir="$RPM_TMPDIR"
 
         old_alias_all=$(mktemp old-alias-all-XXXXXX --tmpdir=/tmp)


### PR DESCRIPTION
The first change in the PR fixed kmod search path (as there are debug modules present as well, this was no longer unique).

The second one relaxes the stringent requirement that the set of PCI IDs be equal on a string basis to the requirement that they be syntactically equivalent up to shell pattern expansion (cf. commit message for an example).

Signed-off-by: Cestmir Kalina <ckalina@redhat.com>