### PR TITLE
fs/xfs/xfstests: remove install_dbench function

### DIFF
--- a/filesystems/xfs/xfstests/install.sh
+++ b/filesystems/xfs/xfstests/install.sh
@@ -261,7 +261,7 @@ function install_xfs()
 {
 	install_xfsprogs
 	install_xfsdump
-	install_dbench
+	#install_dbench
 	install_fio
 	install_duperemove
 }

--- a/filesystems/xfs/xfstests/runtest.sh
+++ b/filesystems/xfs/xfstests/runtest.sh
@@ -24,7 +24,6 @@ dmesg -c >/dev/null
 
 . ./dep-install.sh
 . ./misc.sh
-. ./check.sh
 . ./devices.sh
 . ./install.sh
 . ./xfstests-preset.sh


### PR DESCRIPTION
It's unnecessary for the tests we are running. Remove sourcing
check.sh by the way as it has been dropped while porting.

Signed-off-by: Murphy Zhou <xzhou@redhat.com>