### PR TITLE
stress-ng: blacklist vforkmany on ppc64le

### DIFF
--- a/stress/stress-ng/runtest.sh
+++ b/stress/stress-ng/runtest.sh
@@ -84,6 +84,13 @@ ProcessSizeMax=0
 EOF
         rlRun "systemctl mask --now systemd-coredump.socket" 0 "Masking and stopping systemd-coredump.socket"
     fi
+
+    # blacklist tests on certain arch or RHEL release
+    if [ "$(uname -i)" = "ppc64le" ]; then
+        # TODO: open BZ: vforkmany triggers kernel "BUG: soft lockup" on ppc64le
+        sed -ie '/vforkmany/d' os.stressors
+    fi
+
 rlPhaseEnd
 
 rlPhaseStartTest


### PR DESCRIPTION
The kernel often reports soft lockups during vforkmany on ppc64le systems:
watchdog: BUG: soft lockup - CPU#83 stuck for 22s! [stress-ng-vfork:127885]