### PR TITLE
stress-ng: use rhts-abort to abort

### DIFF
--- a/stress/stress-ng/runtest.sh
+++ b/stress/stress-ng/runtest.sh
@@ -54,6 +54,7 @@ rlPhaseStartSetup
     # if stress-ng triggers a panic and reboot, then abort the test
     if [ $REBOOTCOUNT -ge 1 ] ; then
         rlDie "Aborting due to system crash and reboot"
+        rhts-abort -t recipe
     fi
 
     rlLog "Downloading stress-ng from source"


### PR DESCRIPTION
The beakerlib functions like rlDie and rlAssert* report a FAIL or WARN
status, but we want it to be ABORT, so use the rhts-abort command
instead of a beakerlib function.