### PR TITLE
Report a failure if the kernel doesn't install

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -227,6 +227,7 @@ function download_install_package()
   $YUM install -y $1 2>&1 | tee -a ${OUTPUTFILE}
   if [ $? -ne 0 ]; then
     echo "Failed to install $2!" | tee -a ${OUTPUTFILE}
+    report_result ${TEST} FAIL 1
     rhts-abort -t recipe
     exit 1
   fi


### PR DESCRIPTION
The comment says we should report a failure and abort but no failure was
actually reported here. Fix it.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>