### PR TITLE
legacy: Add RPM package presence checks

### DIFF
--- a/legacy/shared/rpm-utils.sh
+++ b/legacy/shared/rpm-utils.sh
@@ -137,12 +137,26 @@ function __yum_call()
 
 function rpm_install_add()
 {
-    RPM_INSTALL+=("$@")
+        for pkg in "$@"
+        do
+                if [ -z "$(rpm -qa $pkg | head -n 1)" ]
+                then
+                        continue
+                fi
+                RPM_INSTALL+=("$pkg")
+        done
 }
 
 function rpm_extract_add()
 {
-    RPM_EXTRACT+=("$@")
+        for pkg in "$@"
+        do
+                if [ -z "$(rpm -qa $pkg | head -n 1)" ]
+                then
+                        continue
+                fi
+                RPM_EXTRACT+=("$pkg")
+        done
 }
 
 function rpm_install()


### PR DESCRIPTION
Due to differences in OS releases, kernel-modules{,-extra} might not be
present. Remedy that by first checking whether or not given package is
available prior to install/unpack attempts.

Signed-off-by: Čestmír Kalina <ckalina@redhat.com>