### PR TITLE
Mcondotta arm apollo

### DIFF
--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -34,7 +34,7 @@ function check_virt_support
             #      "journalctl -k"
             #
             journalctl -k | \
-                egrep -iq "kvm.*: Hyp mode initialized successfully"
+                egrep -iq "kvm.*: (Hyp|VHE) mode initialized successfully"
         fi
         return $?
     elif [[ $hwpf == "ppc64" || $hwpf == "ppc64le" ]]; then

--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -26,7 +26,7 @@ function check_virt_support
     elif [[ $hwpf == "aarch64" ]]; then
         dmesg | egrep -iq "kvm"
         if (( $? == 0 )); then
-            dmesg | egrep -iq "kvm.*: Hyp mode initialized successfully"
+            dmesg | egrep -iq "kvm.*: (Hyp|VHE) mode initialized successfully"
         else
             #
             # XXX: Note that the harness (i.e. beaker) does clear dmesg, hence


### PR DESCRIPTION
The ARM Apollo Hardware has a different signature in journalctl/dmesg to detect KVM initialization.
Update the regular expression to account for that to enable Apollo hardware to run KVM Unit Tests.
Tests ran on Apollo hardware:
aarch64: https://beaker.engineering.redhat.com/jobs/3586593