### PR TITLE
Fix python for RHEL8.1.

### DIFF
--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -128,7 +128,7 @@ if [ -z "$QEMU" ]; then
 fi
 
 # if running on rhel8, use python3
-if grep --quiet 8.0 /etc/redhat-release;then
+if grep --quiet "release 8." /etc/redhat-release && [ ! -f /usr/bin/python ];then
     ln -s /usr/libexec/platform-python /usr/bin/python
 fi
 


### PR DESCRIPTION
The run_test.sh which triggers the KVM Unit Tests was only prepared for RHEL8.0 provisioned systems. The way it was fixing the python symlink did not work for RHEL8.1.
Fixed it to work for any RHEL8.X system. Failure to create the symlink cause all KVM Unit Tests to fail.
Test job:
aarch64: https://beaker.engineering.redhat.com/jobs/3590376