### PR TITLE
distribution/kernel-fips-mode: add test for kernel FIPS mode

### DIFF
--- a/distribution/kernel-fips-mode/Makefile
+++ b/distribution/kernel-fips-mode/Makefile
@@ -1,0 +1,62 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /distribution/kernel-fips-mode
+#   Description: Test kernel FIPS 140 mode
+#   Authors: Ondrej Moris <omoris@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export TEST=/distribution/kernel-fips-mode
+export TESTVERSION=1.0
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	test -x runtest.sh || chmod a+x runtest.sh
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Ondrej Moris <omoris@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     Test kernel FIPS 140 mode" >> $(METADATA)
+	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "TestTime:        30m" >> $(METADATA)
+	@echo "Priority:        Normal" >> $(METADATA)
+	@echo "License:         GPLv2" >> $(METADATA)
+	@echo "Confidential:    no" >> $(METADATA)
+	@echo "Destructive:     no" >> $(METADATA)
+	@echo "Requires:        crypto-policies" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/distribution/kernel-fips-mode/PURPOSE
+++ b/distribution/kernel-fips-mode/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of /distribution/kernel-fips-mode
+Description: Test kernel FIPS 140 mode
+Author: Ondrej Moris <omoris@redhat.com>

--- a/distribution/kernel-fips-mode/README.md
+++ b/distribution/kernel-fips-mode/README.md
@@ -1,0 +1,16 @@
+# kernel-fips-mode
+Test kernel FIPS 140 mode. 
+Test Maintainer: [Ondrej Moris](mailto:omoris@redhat.com)
+
+### Description
+Test enables FIPS mode and reboot the system to boot into FIPS mode. After successful boot FIPS mode is disabled again.
+
+### How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'. For a complete detail, see PURPOSE file.
+
+### Execute the test
+```bash
+$ make run
+```
+### Warning 
+This test might be potentially destructive because any FIPS issue in kernel usually causes kernel panic and breaks subsequent testing. Therefore it is recommended to either run this test in isolation or to run it as the last test.

--- a/distribution/kernel-fips-mode/runtest.sh
+++ b/distribution/kernel-fips-mode/runtest.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /distribution/kernel-fips-mode
+#   Description: Test kernel FIPS 140 mode.
+#   Author: Ondrej Moris <omoris@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh
+. /usr/share/beakerlib/beakerlib.sh
+
+rlJournalStart
+
+    # Before first reboot (FIPS mode is disabled).
+    if [ ! -e /var/tmp/fips-enabled ] && [ ! -e /var/tmp/fips-disabled ]; then
+
+        # SETUP.
+        rlPhaseStartSetup
+
+            # Enable FIPS mode.
+            rlRun "fips-mode-setup --enable" 0
+
+            # Create reboot indication file.
+            rlRun "touch /var/tmp/fips-enabled" 0
+
+        rlPhaseEnd
+
+        # Reboot.
+        rhts-reboot
+
+    # After second reboot (FIPS mode is disabled again).
+    elif [ -e /var/tmp/fips-disabled ]; then
+
+        # VERIFICATION (2/2).
+        rlPhaseStartTest
+
+            rlRun -s "fips-mode-setup --check" 0
+            rlAssertGrep "disabled" $rlRun_LOG
+
+        rlPhaseEnd
+
+        # CLEAN-UP (2/2).
+        rlPhaseStartCleanup
+
+            # Remove reboot indication file.
+            rlRun "touch /var/tmp/fips-disabled" 0
+
+        rlPhaseEnd
+
+        rlJournalPrintText
+
+        rlJournalEnd
+
+        exit 0
+    fi
+
+    # VERIFICATION (1/2).
+    rlPhaseStartTest
+
+        # Check the state of FIPS mode.
+        rlRun -s "fips-mode-setup --check" 0
+        rlAssertGrep "enabled" $rlRun_LOG
+
+    rlPhaseEnd
+
+    # CLEAN-UP (1/2).
+    rlPhaseStartCleanup
+
+        # Remove reboot indication file.
+        rlRun "rm -f /var/tmp/fips-enabled" 0
+
+        # Disable FIPS mode.
+        rlRun "fips-mode-setup --disable" 0
+        rlRun "rm -f /etc/dracut.conf.d/40-fips.conf /etc/system-fips && dracut -v -f" 0
+
+        # Create reboot indication file.
+        rlRun "touch /var/tmp/fips-disabled" 0
+
+    rlPhaseEnd
+
+    rhts-reboot
+
+rlJournalPrintText
+
+rlJournalEnd


### PR DESCRIPTION
Test for kernel FIPS mode. It is applicable for RHEL-8 only and it might be potentially destructive. Any kernel FIPS issue might cause kernel panic and break subsequent testing. Therefore it is important to run this test either in separation or as the last test.

Signed-off-by: Ondrej Moris <omoris@redhat.com>