### PR TITLE
module-load: remove ipt_ULOG from the module list

### DIFF
--- a/misc/module-load/modules.f18
+++ b/misc/module-load/modules.f18
@@ -383,7 +383,6 @@ ipt_CLUSTERIP
 ipt_ECN
 ipt_MASQUERADE
 ipt_rpfilter
-ipt_ULOG
 ip_vs
 ip_vs_dh
 ip_vs_ftp

--- a/misc/module-load/modules.rhel6
+++ b/misc/module-load/modules.rhel6
@@ -123,7 +123,6 @@ arp_tables
 ipt_CLUSTERIP
 nf_nat_pptp
 ipt_LOG
-ipt_ULOG
 ipt_ECN
 nf_nat_h323
 nf_nat_proto_udplite

--- a/misc/module-load/modules.rhel7
+++ b/misc/module-load/modules.rhel7
@@ -146,7 +146,6 @@ ipt_MASQUERADE
 ipt_NETMAP
 ipt_REDIRECT
 ipt_REJECT
-ipt_ULOG
 ip_vs
 ip_vs_dh
 ip_vs_ftp


### PR DESCRIPTION
nfnetlink_log and ipt_ULOG can conflict with each other, so remove
ipt_ULOG from the list.  (RHBZ#1716856)