### PR TITLE
kdump/include: Setting crashkernel mem to a range 

### DIFF
--- a/kdump/include/runtest.sh
+++ b/kdump/include/runtest.sh
@@ -428,8 +428,8 @@ DefKdumpMem()
         fi
 
     elif $IS_RHEL8; then
-        if   [[ "${K_ARCH}"  = "x86_64" ]]; then args="crashkernel=160M"
-        elif [[ "${K_ARCH}"  = "s390x"  ]]; then args="crashkernel=160M"
+        if   [[ "${K_ARCH}"  = "x86_64" ]]; then args="crashkernel=0M-64G:160M,64G-1T:256M,1T-:512M"
+        elif [[ "${K_ARCH}"  = "s390x"  ]]; then args="crashkernel=0M-64G:160M,64G-1T:256M,1T-:512M"
         elif [[ "${K_ARCH}"  = ppc64*  ]]; then
             args="crashkernel=0M-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G"
         elif [[ "${K_ARCH}"  = "aarch64"  ]]; then args="crashkernel=512M"


### PR DESCRIPTION
Fedora or upstream kernel doesn't support crashkernel=auto. Setting crashkernel to 160M may cause kdump kernel OOM on large machines. So setting it to a range instead. The range is same as how crashkernel=auto works on rhel kernels.

Signed-off-by: xiawu <xiawu@redhat.com>