### PR TITLE
legacy: Use nightly repo for pci id/kabi-whitelist checks, add RHEL7-specific package for pci id comparison

### DIFF
--- a/legacy/pci_id/02-pci-id.sh
+++ b/legacy/pci_id/02-pci-id.sh
@@ -90,6 +90,7 @@ function main()
         echo
 
         # -- Download and extract the baseline kernel RPMS
+        rpm_extract_add "kernel"
         rpm_extract_add "kernel-modules"
         rpm_extract_add "kernel-modules-extra"
         rpm_extract

--- a/legacy/pci_id/Makefile
+++ b/legacy/pci_id/Makefile
@@ -67,6 +67,7 @@ $(METADATA): Makefile
 	@echo "Requires:        zstd" >> $(METADATA)
 	@echo "Requires:        tar" >> $(METADATA)
 	@echo "Requires:        binutils" >> $(METADATA)
+	@echo "Requires:        yum-utils" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/legacy/shared/rpm-utils.sh
+++ b/legacy/shared/rpm-utils.sh
@@ -175,7 +175,8 @@ function rpm_install()
 
 function rpm_extract()
 {
-        __yum_call --downloadonly --downloaddir=$RPM_TMPDIR "${RPM_EXTRACT[@]}"
+        yumdownloader --disablerepo='*' --enablerepo=rhel-latest \
+                      --downloaddir=$RPM_TMPDIR "${RPM_EXTRACT[@]}"
 
         if test $? -gt 0
         then

--- a/legacy/whitelist/Makefile
+++ b/legacy/whitelist/Makefile
@@ -59,6 +59,7 @@ $(METADATA): Makefile
 	@echo "Requires:        file" >> $(METADATA)
 	@echo "Requires:        gawk" >> $(METADATA)
 	@echo "Requires:        binutils" >> $(METADATA)
+	@echo "Requires:        yum-utils" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)


### PR DESCRIPTION
 - Nightly repository is required for proper baseline comparison.
 - Add `yum-utils` requires -- use yumdownloader instead of `(yum|dnf) ([re]install|update) --downloadonly` -- simplifies RPM download code
 - Also add kernel package as a source for kernel modules for RHEL7.

Signed-off-by: Čestmír Kalina <ckalina@redhat.com>