### PR TITLE
Add CPU Freq Driver Test (x86_64 only) (#923)

### DIFF
--- a/cpu/common/libutil.sh
+++ b/cpu/common/libutil.sh
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-source ${CDIR%/cpu/driver}/cpu/common/libbkrm.sh
+source $(dirname $(readlink -f $BASH_SOURCE))/libbkrm.sh
 
 TMPDIR=${TMPDIR:-"/tmp"}
 MSR_TOOLS_SRC_URL="https://github.com/intel/msr-tools.git"

--- a/cpu/driver/Makefile
+++ b/cpu/driver/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+export TEST=/kernel/cpu/driver
+export TESTVERSION=1.0
+
+BUILT_FILES= runtest
+
+FILES=$(METADATA) runtest.sh Makefile README.md
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest
+
+runtest: runtest.sh
+	cp $< $@ && chmod +x $@
+
+build: $(BUILT_FILES)
+
+clean:
+
+clobber: clean
+	rm -f *~ $(BUILT_FILES)
+cl: clobber
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:        David Arcari <darcari@redhat.com>" > $(METADATA)
+	@echo "Name:         $(TEST)" >> $(METADATA)
+	@echo "TestVersion:  $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:  cpu frequency driver testing" >> $(METADATA)
+	@echo "Type:         Functional" >> $(METADATA)
+	@echo "TestTime:     10m" >> $(METADATA)
+	@echo "RunFor:       kernel" >> $(METADATA)
+	@echo "Requires:     msr-tools" >> $(METADATA)
+	@echo "Requires:     git" >> $(METADATA)
+	@echo "Requires:     autoconf" >> $(METADATA)
+	@echo "Requires:     automake" >> $(METADATA)
+	@echo "Requires:     make" >> $(METADATA)
+	@echo "Requires:     gcc" >> $(METADATA)
+	@echo "Requires:     bc" >> $(METADATA)
+	@echo "Requires:     python2-lxml" >> $(METADATA)
+	@echo "Requires:     python3-lxml" >> $(METADATA)
+	@echo "RepoRequires: cpu/common" >> $(METADATA)
+	@echo "Priority:     Normal" >> $(METADATA)
+	@echo "License:      GPLv2 or above" >> $(METADATA)
+	@echo "Confidential: no" >> $(METADATA)
+	@echo "Destructive:  no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/cpu/driver/PURPOSE
+++ b/cpu/driver/PURPOSE
@@ -1,0 +1,4 @@
+PURPOSE of /kernel/cpu/driver
+
+DESCRIPTION: Simple test which verifies that the correct cpu frequency driver
+             is loaded

--- a/cpu/driver/README.md
+++ b/cpu/driver/README.md
@@ -1,0 +1,14 @@
+# cpu frequency driver test suite
+It provides cpu frequency driver test.
+Test Maintainer: [David Arcari](mailto:darcari@redhat.com)
+
+## How to run it
+
+### Dependencies
+Please refer to the top-level README.md for common dependencies. Test-specific
+dependencies will automatically be installed when executing 'make run'.
+
+### Execute the test
+```bash
+$ make run
+```

--- a/cpu/driver/runtest.sh
+++ b/cpu/driver/runtest.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+FILE=$(readlink -f ${BASH_SOURCE})
+NAME=$(basename $FILE)
+CDIR=$(dirname $FILE)
+TEST=${TEST:-"$0"}
+TMPDIR=/var/tmp/$(date +"%Y%m%d%H%M%S")
+
+source ${CDIR%/cpu/driver}/cpu/common/libbkrm.sh
+source ${CDIR%/cpu/driver}/cpu/common/libutil.sh
+
+function verify_intel_cpufreq_driver
+{
+    rlLog "Start to verify intel cpu freq driver"
+
+    rlRun "lscpu | grep 'hwp'" $BKRM_RC_ANY
+    if (( $? == 0 )); then
+        rlRun "rdmsr 0x770"
+        if (( $? != 0 )); then
+            rlSetReason $BKRM_UNSUPPORTED \
+                "intel system has HWP, but it is not enabled"
+            return $BKRM_UNSUPPORTED
+        fi
+    else
+        rlRun "ls /sys/devices/system/cpu/intel_pstate/"
+        if (( $? != 0 )); then
+            rlSetReason $BKRM_FAIL \
+                "intel system does not have HWP, intel_pstate is not active"
+            return $BKRM_FAIL
+        fi
+    fi
+
+    rlLog "PASS"
+    return $BKRM_PASS
+}
+
+function verify_amd_cpufreq_driver
+{
+    rlLog "Start to verify amd cpu freq driver"
+
+    typeset family=$(cat /proc/cpuinfo | grep family | \
+                     sort -u | awk '{print $4}')
+
+    # verify family is >= 15h
+    if (( $family >= 0x15 )); then
+        typeset driver=$(lsmod | grep cpufreq | awk '{print $1}')
+        if [[ $driver != "acpi_cpufreq" ]]; then
+            rlSetReason $BKRM_FAIL \
+                "AMD system is not running acpi_cpufreq driver"
+            return $BKRM_FAIL
+        fi
+    else
+        rlSetReason $BKRM_UNSUPPORTED \
+            "this test is not valid for the AMD family"
+        return $BKRM_UNSUPPORTED
+    fi
+
+    rlLog "PASS"
+    return $BKRM_PASS
+}
+
+function runtest
+{
+    typeset vendor_str=$(cat /proc/cpuinfo | grep vendor | \
+                         sort -u | awk '{print $3}')
+    case $vendor_str in
+    GenuineIntel)
+        verify_intel_cpufreq_driver
+        typeset -i ret=$?
+        ;;
+
+    AuthenticAMD)
+        verify_amd_cpufreq_driver
+        typeset -i ret=$?
+        ;;
+
+    *) # UNSUPPORTED
+        rlSetReason $BKRM_UNSUPPORTED \
+            "it is an unsupported vendor: $vendor_str"
+        typeset -i ret=$BKRM_UNSUPPORTED
+        ;;
+    esac
+
+    return $ret
+}
+
+function startup
+{
+    if [[ $(virt-what) == "kvm" ]]; then
+        rlSetReason $BKRM_UNSUPPORTED \
+            "this test is unsupported in kvm"
+        return $BKRM_UNSUPPORTED
+    fi
+
+    if [[ ! -d $TMPDIR ]]; then
+        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_FAIL
+    fi
+
+    # setup msr tools as package 'msr-tools' is not installed by default
+    msr_tools_setup
+    if (( $? != 0 )); then
+        rlSetReason $BKRM_FATAL "fail to setup msr tools"
+        return $BKRM_FATAL
+    fi
+
+    return $BKRM_PASS
+}
+
+function cleanup
+{
+    msr_tools_cleanup || return $BKRM_FAIL
+    rlRun "rm -rf $TMPDIR" $BKRM_RC_ANY
+    return $BKRM_PASS
+}
+
+main
+exit $?


### PR DESCRIPTION
The test only supports Intel CPU because utility `msr-tools` is a must. And test is unsupported in kvm, e.g.
```bash
root# virt-what 
kvm
root# rdmsr 0x606
rdmsr: CPU 0 cannot read MSR 0x00000606
```