### PR TITLE
fs/xfs/xfstests: do not report failure if subcase does not exist

### DIFF
--- a/filesystems/xfs/xfstests/RUNTESTS
+++ b/filesystems/xfs/xfstests/RUNTESTS
@@ -217,5 +217,3 @@ generic/508
 generic/509
 generic/510
 generic/511
-shared/001
-shared/003

--- a/filesystems/xfs/xfstests/xfstests-run.sh
+++ b/filesystems/xfs/xfstests/xfstests-run.sh
@@ -29,7 +29,6 @@ function check_tests()
 			xlog head -n 10 tests/$XFSTEST
 		else
 			echoo "The test $XFSTEST does not seem to exist."
-			report $XFSTEST FAIL 0
 			continue
 		fi
 		MOUNT_OPTIONS="$MOUNT_OPTS" MKFS_OPTIONS="$MKFS_OPTS" xlog ./check $CHECK_OPTS $XFSTEST


### PR DESCRIPTION
Remove 2 testcases that has been renamed upstream.

Signed-off-by: Murphy Zhou <xzhou@redhat.com>