### PR TITLE
kdump-sysrq-c: Check kernel debuginfo vmlinux file

### DIFF
--- a/kdump/kdump-sysrq-c/runtest.sh
+++ b/kdump/kdump-sysrq-c/runtest.sh
@@ -41,6 +41,7 @@ Crash()
 
         # Analyse the vmcore by crash utilities
         PrepareCrash
+        [ $? -eq 1 ] && return
 
         # Only check the return code of this session.
         cat <<EOF > "${K_TESTAREA}/crash-simple.cmd"


### PR DESCRIPTION
kernel-debuginfo package cannot be installed from a yum source if the kernel is installed from a tar.gz.
In this case, the "/usr/lib/debug/lib/modules/$(uname -r)/vmlinux" is supposed to be taken care by cki boot test. Then kdump-sysrq-c will only check if the file exists.

Signed-off-by: xiawu <xiawu@redhat.com>