### PR TITLE
redhat-rpm-config/detect-kabi-provides: Module.symvers search change

### DIFF
--- a/packages/redhat-rpm-config/detect-kabi-provides/symvers-foo.spec
+++ b/packages/redhat-rpm-config/detect-kabi-provides/symvers-foo.spec
@@ -22,7 +22,11 @@ VER=`rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel | head -n 1 2> /dev/nu
 #zcat $SYMFILE | head 2> /dev/null | gzip -c > %{buildroot}/boot/symvers-foo.gz
 
 # due to rhel-8/bz1582110 we need to do this
-SYMFILE=`find /usr/src/kernels -name Module.symvers | egrep -v '(debug|zfcpdump)' | head -1`
+# Ensure currently running kernel is used. There might be multiple kernels
+# installed in /usr/src/kernels; pick currently running one (the tested
+# one) to allow for patch impact testing (i.e., ensure that the patched
+# kernel's Module.symvers is compatible w/ rpm utils)
+SYMFILE=`find /usr/src/kernels -name Module.symvers -path "*$(uname -r)*" | egrep -v '(debug|zfcpdump)' | head -1`
 head $SYMFILE | gzip -c > %{buildroot}/boot/symvers-foo.gz
 
 %files


### PR DESCRIPTION
As there might be multiple kernels installed, ensure that the currently
running kernel's Module.symvers file is used (i.e., the tested one).

Signed-off-by: Čestmír Kalina <ckalina@redhat.com>