### PR TITLE
Port test case 'power-management/rapl/powercap' (#1017)

### DIFF
--- a/cpu/common/libbkrm.sh
+++ b/cpu/common/libbkrm.sh
@@ -28,7 +28,7 @@ BKRM_RC_ANY="0-255" # To assist rlRun() to support any return code
 BKRM_PASS=0        # should go to rlPass()
 BKRM_FAIL=1        # should go to rlFail()
 BKRM_UNSUPPORTED=2 # should go to rlSkip()
-BKRM_FATAL=3       # should go to rlAbort()
+BKRM_UNINITIATED=3 # should go to rlAbort()
 
 #
 # A simple wrapper function to report result
@@ -42,7 +42,7 @@ function rlReportResult
         $BKRM_PASS) rlPass $argv ;;
         $BKRM_FAIL) rlFail "$g_reason_fail #$argv#" ;;
         $BKRM_UNSUPPORTED) rlSkip "$g_reason_unsupported #$argv#" ;;
-        $BKRM_FATAL) rlAbort "$g_reason_fatal #$argv#" ;;
+        $BKRM_UNINITIATED) rlAbort "$g_reason_uninitiated #$argv#" ;;
         *) ;;
     esac
 }
@@ -58,7 +58,7 @@ function rlSetReason
     case $rc in
         $BKRM_FAIL) g_reason_fail="$@" ;;
         $BKRM_UNSUPPORTED) g_reason_unsupported="$@" ;;
-        $BKRM_FATAL) g_reason_fatal="$@" ;;
+        $BKRM_UNINITIATED) g_reason_uninitiated="$@" ;;
         *) ;;
     esac
 }

--- a/cpu/common/libutil.sh
+++ b/cpu/common/libutil.sh
@@ -47,7 +47,7 @@ EOF
 
     rlRun "chmod +x $script" $BKRM_RC_ANY
     rlRun "cat -n $script" $BKRM_RC_ANY
-    rlRun "bash $script" || return $BKRM_FATAL
+    rlRun "bash $script" || return $BKRM_UNINITIATED
 
     return $BKRM_PASS
 }

--- a/cpu/driver/runtest.sh
+++ b/cpu/driver/runtest.sh
@@ -110,14 +110,14 @@ function startup
     fi
 
     if [[ ! -d $TMPDIR ]]; then
-        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_FAIL
+        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_UNINITIATED
     fi
 
     # setup msr tools as package 'msr-tools' is not installed by default
     msr_tools_setup
     if (( $? != 0 )); then
-        rlSetReason $BKRM_FATAL "fail to setup msr tools"
-        return $BKRM_FATAL
+        rlSetReason $BKRM_UNINITIATED "fail to setup msr tools"
+        return $BKRM_UNINITIATED
     fi
 
     return $BKRM_PASS
@@ -125,7 +125,7 @@ function startup
 
 function cleanup
 {
-    msr_tools_cleanup || return $BKRM_FAIL
+    msr_tools_cleanup
     rlRun "rm -rf $TMPDIR" $BKRM_RC_ANY
     return $BKRM_PASS
 }

--- a/cpu/idle/runtest.sh
+++ b/cpu/idle/runtest.sh
@@ -36,14 +36,14 @@ function runtest
 function startup
 {
     if [[ ! -d $TMPDIR ]]; then
-        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_FAIL
+        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_UNINITIATED
     fi
 
     # setup msr tools as package 'msr-tools' is not installed by default
-    msr_tools_setup || return $?
+    msr_tools_setup
     if (( $? != 0 )); then
-        rlSetReason $BKRM_FATAL "fail to setup msr tools"
-        return $BKRM_FATAL
+        rlSetReason $BKRM_UNINITIATED "fail to setup msr tools"
+        return $BKRM_UNINITIATED
     fi
 
     # check this test is supported by CPU
@@ -59,7 +59,7 @@ function startup
 
 function cleanup
 {
-    msr_tools_cleanup || return $BKRM_FAIL
+    msr_tools_cleanup
     rlRun "rm -rf $TMPDIR" $BKRM_RC_ANY
     return $BKRM_PASS
 }

--- a/power-management/rapl/powercap/Makefile
+++ b/power-management/rapl/powercap/Makefile
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+export TEST		:= /kernel/power-management/rapl/powercap
+export TESTVERSION	:= 1.0
+
+BUILT_FILES		= runtest
+
+FILES			= $(METADATA) \
+			  Makefile \
+			  PURPOSE \
+			  README.md \
+			  runtest.sh
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest
+
+runtest: runtest.sh
+	cp $< $@ && chmod +x $@
+
+build: $(BUILT_FILES)
+
+clean:
+	rm -f *~ $(BUILT_FILES)
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:        Erik Hamera <ehamera@redhat.com>" > $(METADATA)
+	@echo "Name:         $(TEST)" >> $(METADATA)
+	@echo "TestVersion:  $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:  Confirm RAPL is supported" >> $(METADATA)
+	@echo "Type:         Sanity" >> $(METADATA)
+	@echo "TestTime:     5m" >> $(METADATA)
+	@echo "RunFor:       kernel" >> $(METADATA)
+	@echo "Requires:     kernel" >> $(METADATA)
+	@echo "Requires:     python2-lxml" >> $(METADATA)
+	@echo "Requires:     python3-lxml" >> $(METADATA)
+	@echo "RepoRequires: cpu/common" >> $(METADATA)
+	@echo "Priority:     Normal" >> $(METADATA)
+	@echo "License:      GPLv2 or above" >> $(METADATA)
+	@echo "Confidential: no" >> $(METADATA)
+	@echo "Destructive:  no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/power-management/rapl/powercap/PURPOSE
+++ b/power-management/rapl/powercap/PURPOSE
@@ -1,0 +1,19 @@
+PURPOSE of /kernel/power-management/rapl/powercap
+Description: Simple test of powercap.
+Author: Erik Hamera <ehamera@redhat.com>
+
+RAPL = Running Average Power Limit
+
+Check RAPL functions. It measures power consumption on idle and on full load on
+all cores. Then it will cap it to the average power and measures power
+consumption under full load again.
+
+There are two magic constants in it:
+- measure time is 30 seconds
+- 10% maximal difference between measured and capped value until test is
+  going to fail
+
+These constants are __NOT__ emerging from intel's datasheets or something like
+that. They __ARE__ just wild guess which should suppress false alarms due to
+started daemons and other fluctuations. Feel free to change it if your guess
+is better, than mine.

--- a/power-management/rapl/powercap/README.md
+++ b/power-management/rapl/powercap/README.md
@@ -1,0 +1,13 @@
+# powercap test suite
+Simple test of powercap. \
+Test Maintainer: [Erik Hamera](mailto:ehamera@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies.
+Test-specific dependencies will automatically be installed when
+executing 'make run'. For a complete detail, see PURPOSE file.
+
+### Execute the test
+```bash
+$ make run
+```

--- a/power-management/rapl/powercap/runtest.sh
+++ b/power-management/rapl/powercap/runtest.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+FILE=$(readlink -f ${BASH_SOURCE})
+NAME=$(basename $FILE)
+CDIR=$(dirname $FILE)
+TEST=${TEST:-"$0"}
+TMPDIR=/var/tmp/$(date +"%Y%m%d%H%M%S")
+
+source ${CDIR%/power-management/rapl/powercap}/cpu/common/libbkrm.sh
+
+# XXX: This function is from power-management/rapl/powercap/cap.sh
+function set_cap
+{
+    typeset energy=${1?"*** energy_in_microjoules***"}
+    typeset cpu_sockets=$(lscpu | grep 'Socket(s):' | \
+                          sed 's/^Socket(s):[^0-9]*\([0-9]*\)/\1/')
+    typeset cap_energy=$(( energy / cpu_sockets ))
+    typeset rapl_path="/sys/devices/virtual/powercap/intel-rapl"
+    typeset rapl=$(ls -1 $rapl_path | grep 'intel-rapl:')
+    typeset cpu=""
+    for cpu in $rapl; do
+        echo $cap_energy > $rapl_path/$cpu/constraint_0_power_limit_uw
+    done
+}
+
+# XXX: This function is from power-management/rapl/powercap/read_cap.sh
+function get_cap
+{
+    typeset rapl_path="/sys/devices/virtual/powercap/intel-rapl"
+    typeset rapl=$(ls -1 "$rapl_path" | grep 'intel-rapl:')
+
+    typeset cpu=""
+    typeset e=0
+    for cpu in $rapl; do
+        e_cpu=$(cat $rapl_path/$cpu/constraint_0_power_limit_uw)
+        (( e += e_cpu ))
+    done
+
+    echo $e
+}
+
+# XXX: This function is from power-management/rapl/powercap/energy.sh
+function get_energy
+{
+    typeset time=${1:-"30"} # Default is 30 secs
+    typeset rapl_path="/sys/devices/virtual/powercap/intel-rapl"
+    typeset rapl=$(ls -1 "$rapl_path" | grep 'intel-rapl:')
+
+    typeset cpu=""
+    typeset e1=0
+    for cpu in $rapl; do
+        typeset e_cpu=$(cat "$rapl_path/$cpu/energy_uj"*)
+        (( e1 += e_cpu ))
+    done
+
+    sleep $time
+
+    typeset e2=0
+    for cpu in $rapl; do
+        typeset e_cpu=$(cat "$rapl_path/$cpu/energy_uj"*)
+        (( e2 += e_cpu ))
+    done
+
+    typeset e=$(( (e2 - e1) / time ))
+    echo $e
+}
+
+# XXX: This function is from power-management/rapl/powercap/load1.sh
+function load1
+{
+    typeset sleeptime=${1:-"1"}
+
+    # do some load
+    dd if=/dev/zero > /dev/null 2>&1 &
+    typeset loadpid=$!
+
+    sleep $sleeptime
+    # wait a bit longer, than length of test
+    sleep 10
+
+    # kill the load
+    kill -9 $loadpid
+}
+
+# XXX: This function is from power-management/rapl/powercap/load_m.sh
+function loadm
+{
+    typeset -i timeout=$1
+    typeset -i nthreads=$2
+    typeset -i i
+    for (( i = 0; i < $nthreads; i++ )); do
+        (load1 $timeout) > /dev/null 2>&1 &
+        typeset pid=$!
+        rlLog "load1[$i] is started, pid=$pid"
+    done
+}
+
+# XXX: This function is from power-management/rapl/powercap/test_capping.sh
+function test_capping
+{
+    # measurement time should be bigger than
+    # cat /sys/devices/virtual/powercap/intel-rapl/intel-rapl\:0/constraint_0_time_window_us
+    # which is 1 sec by default (at least on systems I have seen so far).
+    typeset measurement_time=30
+    typeset load_time=$(( measurement_time + 20 ))
+
+    # 1. no load, no cap
+    typeset e_no_no=$(get_energy $measurement_time)
+    rlLog "Power consumtion on uncapped system with no load: $e_no_no microwatts"
+
+    # 2. load, no cap
+    typeset cpus=$(lscpu | grep '^CPU(s):' | \
+                   sed 's/^CPU(s):[^0-9]*\([0-9]*\)/\1/')
+    loadm $load_time $cpus
+    typeset e_full_no=$(get_energy $measurement_time)
+    rlLog "Power consumtion on uncapped system with full load: $e_full_no microwatts"
+
+    # 3. cap to average between full load and no load
+    typeset e_mid=$(( (e_no_no + e_full_no) / 2 ))
+    rlLog "Going to cap the system to: $e_mid microwatts"
+
+    typeset old_cap=$(get_cap)
+    set_cap $e_mid
+    loadm $load_time $cpus
+    typeset e_full_cap=$(get_energy $measurement_time)
+    rlLog "Power consumtion on capped system with full load: $e_full_cap microwatts"
+
+    #
+    # measured_max is maximal measured value which will not cause fail
+    # measured_min is minimal measured value which will not cause fail
+    # *11/10 - add 10% in bash which works in integers only - we're
+    # using microwatts, so numbers are milions to hundreds of milions,
+    # so tehre is no problem with rounding error
+    # *9/10 - substract 10%
+    #
+    typeset measured_max=$(( e_mid * 11 / 10 ))
+    typeset measured_min=$(( e_mid *  9 / 10 ))
+
+    rlLog "capping back to $old_cap"
+    set_cap $old_cap
+
+    rlLog "e_no_no      = $e_no_no"
+    rlLog "e_full_no    = $e_full_no"
+    rlLog "e_mid        = $e_mid"
+    rlLog "e_full_cap   = $e_full_cap"
+    rlLog "measured_max = $measured_max"
+    rlLog "measured_min = $measured_min"
+    if (( e_full_cap > measured_max || e_full_cap < measured_min )); then
+        rlLog "FAIL: measured energy consumption doesn't match capped value"
+        return 1
+    fi
+
+    return 0
+}
+
+#
+# Check CPU vendor is Intel or not
+#
+function is_intel
+{
+    typeset vendor=$(grep vendor /proc/cpuinfo | sort -u | awk '{print $3}')
+    [[ $vendor == "GenuineIntel" ]] && return 0 || return 1
+}
+
+#
+# Check the system is kvm or not
+#
+function is_kvm
+{
+    [[ $(virt-what) == "kvm" ]] && return 0 || return 1
+}
+
+function startup
+{
+    is_kvm
+    if (( $? == 0 )); then
+        rlSetReason $BKRM_UNSUPPORTED "kvm is unsupported"
+        return $BKRM_UNSUPPORTED
+    fi
+
+    is_intel
+    if (( $? != 0 )); then
+        rlSetReason $BKRM_UNSUPPORTED "non-intel CPU is unsupported"
+        return $BKRM_UNSUPPORTED
+    fi
+
+    if [[ ! -d $TMPDIR ]]; then
+        rlRun "mkdir -p -m 0755 $TMPDIR" || return $BKRM_UNINITIATED
+    fi
+
+    return $BKRM_PASS
+}
+
+function cleanup
+{
+    rlRun "rm -rf $TMPDIR" $BKRM_RC_ANY
+    return $BKRM_PASS
+}
+
+function runtest
+{
+    # For debugging
+    rlRun -l "find /sys/devices/ -name *rapl*" $BKRM_RC_ANY
+    rlRun -l "lsmod" $BKRM_RC_ANY
+    rlRun -l "modprobe intel-rapl" || return $BKRM_UNINITIATED
+
+    # Check if capping works, it should take approx 1.5 - 2 minutes
+    test_capping || return $BKRM_FAIL
+    return $BKRM_PASS
+}
+
+main
+exit $?


### PR DESCRIPTION
This is the 1st PR of ticket `FASTMOVING-1017`, the source code saved in `tests/kernel` includes 7 small shell scripts, I converted them to functions being saved into `runtest.sh` to make things simple and achieve better readability.

A manual test on RHEL8/x86_64 is done, here is the test log:
- http://pastebin.test.redhat.com/781779