### PR TITLE
Add RHEL 8 support for podman test

### DIFF
--- a/container/podman/runtest.sh
+++ b/container/podman/runtest.sh
@@ -27,6 +27,13 @@ if [ -z "$pkg" ] ; then
     rhts-abort -t recipe
 fi
 
+# RHEL 8 will install podman-tests, but it will not install bats. We can use
+# the Fedora 30 package instead.
+if [ ! -x /usr/bin/bats ]; then
+    dnf -y --nogpgcheck install \
+        http://mirrors.kernel.org/fedora/releases/30/Everything/x86_64/os/Packages/b/bats-1.1.0-2.fc30.noarch.rpm
+fi
+
 # Use the multi-arch Fedora image to ensure podman's tests pass
 # on non-x86 architectures.
 export PODMAN_TEST_IMAGE_REGISTRY="docker.io"

--- a/container/podman/runtest.sh
+++ b/container/podman/runtest.sh
@@ -23,7 +23,7 @@ ret=0
 # Verify that podman-tests is installed
 pkg=$(rpm -qa | grep podman-tests)
 if [ -z "$pkg" ] ; then
-    report_result $TEST WARN
+    report_result "${TEST}" WARN
     rhts-abort -t recipe
 fi
 
@@ -42,14 +42,14 @@ export PODMAN_TEST_IMAGE_NAME="fedora"
 export PODMAN_TEST_IMAGE_TAG="latest"
 
 # Run the podman system tests.
-bats /usr/share/podman/test/system/ | tee -a $OUTPUTFILE
+bats /usr/share/podman/test/system/ | tee -a "${OUTPUTFILE}"
 ret=$?
 
-echo "Test finished" | tee -a $OUTPUTFILE
+echo "Test finished" | tee -a "${OUTPUTFILE}"
 
 if [ $ret != 0 ] ; then
-    report_result $TEST FAIL $ret
+    report_result "${TEST}" FAIL $ret
 else
     # all is well
-    report_result $TEST PASS 0
+    report_result "${TEST}" PASS 0
 fi


### PR DESCRIPTION
This PR adds initial RHEL 8 support for the podman system integration test and fixes some warnings from `shellcheck`.