### PR TITLE
Add nmap-ncat for KVM unit tests

### DIFF
--- a/vm/kvm-unit-tests/Makefile
+++ b/vm/kvm-unit-tests/Makefile
@@ -57,6 +57,7 @@ $(METADATA): Makefile
 	@echo "Requires:        qemu-kvm" >> $(METADATA)
 	@echo "Requires:        git" >> $(METADATA)
 	@echo "Requires:        gcc" >> $(METADATA)
+	@echo "Requires:        nmap-ncat" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv3" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)


### PR DESCRIPTION
If `/usr/bin/nc` is not present, the following error appears during testing:

```
run_migration timeout -k 1s --foreground 90s /usr/libexec/qemu-kvm -nodefaults -machine pseries,accel=kvm -bios powerpc/boot_rom.bin -display none -serial stdio -kernel powerpc/sprs.elf -smp 1 -append -w # -initrd /tmp/tmp.XCtZmrEE9W
run_migration needs nc (netcat)
```

`nmap-ncat` appears to the correct package on RHEL 7, RHEL 8, and Fedora 30.

Signed-off-by: Major Hayden <major@redhat.com>