### PR TITLE
vm/kvm-self-tests: Add the patch back for building Kernel Self Tests for older versions (prior to .97, RHEL 8.0.X)

### DIFF
--- a/vm/kvm-self-tests/patches/bitmap.h.patch
+++ b/vm/kvm-self-tests/patches/bitmap.h.patch
@@ -1,0 +1,27 @@
+--- a/tools/include/linux/bitmap.h	2019-03-28 23:18:27.245070526 -0400
++++ b/tools/include/linux/bitmap.h	2019-03-28 23:20:26.958597334 -0400
+@@ -97,6 +97,24 @@
+ }
+
+ /**
++ * test_and_clear_bit - Clear a bit and return its old value
++ * @nr: Bit to clear
++ * @addr: Address to count from
++ */
++static inline int test_and_clear_bit(int nr, volatile unsigned long *addr)
++{
++	unsigned long mask = BIT_MASK(nr);
++	unsigned long *p = ((unsigned long *)addr) + BIT_WORD(nr);
++	unsigned long old;
++	unsigned long flags;
++
++	old = *p;
++	*p = old & ~mask;
++
++	return (old & mask) != 0;
++}
++
++/**
+  * bitmap_alloc - Allocate bitmap
+  * @nbits: Number of bits
+  */

--- a/vm/kvm-self-tests/runtest.sh
+++ b/vm/kvm-self-tests/runtest.sh
@@ -188,6 +188,19 @@ function runtest
     rlAssertExists $tests_srcdir
     rlAssertExists ${outputdir}
 
+    #
+    # XXX: Apply a patch because case 'dirty_log_test' fails to be built, which
+    #      is because patch [1] is missed when backporting to RHEL8 repo. Note
+    #      we should remove the workaround if the case is fixed.
+    #      [1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=07a262cc
+    #
+    # This patch was merged in version 4.18.0-97.el8 only earlier versions need to apply it
+    rlTestVersion "${RELEASE}" "<" "4.18.0-97.el8"
+    if (( $? == 0)); then
+        rlRun "patch -d $linux_srcdir -p1 < patches/bitmap.h.patch" 0 \
+              "Patching via patches/bitmap.h.patch"
+    fi
+
     rlRun "pushd '.'"
 
     # Build tests


### PR DESCRIPTION
This patch will enable CKI to run KVM Self Tests for Kernels that are older than 4.18.0-97 (that do not contain the KVM code rebase).