### PR TITLE
blktests: disable nvme/* for RHEL8 ppc64le

### DIFF
--- a/storage/blk/runtest.sh
+++ b/storage/blk/runtest.sh
@@ -246,7 +246,7 @@ function get_test_cases_nvme
 testcases_default=""
 testcases_default+=" $(get_test_cases_block)"
 testcases_default+=" $(get_test_cases_loop)"
-uname -ri | grep -Eq "5.*aarch64|5.*ppc64|4.18.0-.*rt.*x86_64|3.10.0-.*rt.*x86_64|3.10.0-957.*ppc64|3.10.0-862.*x86_64" || testcases_default+=" $(get_test_cases_nvme)"
+uname -ri | grep -Eq "5.*aarch64|5.*ppc64|4.18.0-.*rt.*x86_64|3.10.0-.*rt.*x86_64|3.10.0-957.*ppc64|3.10.0-862.*x86_64|4.18.0-.*ppc64le" || testcases_default+=" $(get_test_cases_nvme)"
 testcases=${_DEBUG_MODE_TESTCASES:-"$(echo $testcases_default)"}
 test_ws=$CDIR/blktests
 ret=0


### PR DESCRIPTION
Signed-off-by: Yi Zhang <yi.zhang@redhat.com>