### PR TITLE
Add package 'virt-what' to Makefiles

### DIFF
--- a/cpu/driver/Makefile
+++ b/cpu/driver/Makefile
@@ -51,6 +51,7 @@ $(METADATA): Makefile
 	@echo "TestTime:     10m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     msr-tools" >> $(METADATA)
+	@echo "Requires:     virt-what" >> $(METADATA)
 	@echo "Requires:     git" >> $(METADATA)
 	@echo "Requires:     autoconf" >> $(METADATA)
 	@echo "Requires:     automake" >> $(METADATA)

--- a/power-management/cpupower/sanity/Makefile
+++ b/power-management/cpupower/sanity/Makefile
@@ -54,6 +54,7 @@ $(METADATA): Makefile
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     kernel" >> $(METADATA)
 	@echo "Requires:     kernel-tools" >> $(METADATA)
+	@echo "Requires:     virt-what" >> $(METADATA)
 	@echo "Requires:     cpupowerutils" >> $(METADATA)
 	@echo "Requires:     bc" >> $(METADATA)
 	@echo "Requires:     python2-lxml" >> $(METADATA)

--- a/power-management/rapl/powercap/Makefile
+++ b/power-management/rapl/powercap/Makefile
@@ -52,6 +52,7 @@ $(METADATA): Makefile
 	@echo "TestTime:     5m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     kernel" >> $(METADATA)
+	@echo "Requires:     virt-what" >> $(METADATA)
 	@echo "Requires:     python2-lxml" >> $(METADATA)
 	@echo "Requires:     python3-lxml" >> $(METADATA)
 	@echo "RepoRequires: cpu/common" >> $(METADATA)


### PR DESCRIPTION
Command 'virt-what' is not found because the related package is missing, so add it to Makefiles.