### PR TITLE
cpu frequency driver test only runs setup phase on certain jobs (#1098)

### DIFF
--- a/cpu/driver/Makefile
+++ b/cpu/driver/Makefile
@@ -48,7 +48,7 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  cpu frequency driver testing" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     10m" >> $(METADATA)
+	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     msr-tools" >> $(METADATA)
 	@echo "Requires:     git" >> $(METADATA)


### PR DESCRIPTION
Extended the timeout to 30m and also copied the fix from [Rachel's branch](https://github.com/CKI-project/tests-beaker/compare/master...rasibley:cpu_driver_fix?expand=1).
