### PR TITLE
blktests: remove the blacklisted nvme/ test case

### DIFF
--- a/storage/blk/runtest.sh
+++ b/storage/blk/runtest.sh
@@ -216,7 +216,7 @@ function get_test_cases_nvme
 	else
 		#testcases+=" nvme/002" #disable
 		#testcases+=" nvme/003" #disable
-		uname -ri | grep -qE "4.18.0-.*ppc64le" || testcases+=" nvme/004"
+		testcases+=" nvme/004"
 		#testcases+=" nvme/005" modprobe/modprobe -r nvme-core will be failed
 		testcases+=" nvme/006"
 		testcases+=" nvme/007"
@@ -246,8 +246,7 @@ function get_test_cases_nvme
 testcases_default=""
 testcases_default+=" $(get_test_cases_block)"
 testcases_default+=" $(get_test_cases_loop)"
-uname -ri | grep -Eq "5.*aarch64|5.*ppc64|4.18.0-.*rt.*x86_64|3.10.0-.*rt.*x86_64|3.10.0-957.*ppc64|3.10.0-862.*x86_64|\
-4.18.0-.*ppc64le|4.18.0-.*el8_0.ppc64le|4.18.0-.*el8_0.x86_64" || testcases_default+=" $(get_test_cases_nvme)"
+testcases_default+=" $(get_test_cases_nvme)"
 testcases=${_DEBUG_MODE_TESTCASES:-"$(echo $testcases_default)"}
 test_ws=$CDIR/blktests
 ret=0


### PR DESCRIPTION
upstream blktests have some update which may fix the test case issue, so
re-add the test case

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>