### PR TITLE
networking/udp: do not check the return value for modprobe -r

### DIFF
--- a/networking/udp/udp_socket/runtest.sh
+++ b/networking/udp/udp_socket/runtest.sh
@@ -30,7 +30,7 @@ wait_time="2"
 
 rlJournalStart
     rlPhaseStartSetup
-	(uname -r |grep el6) || rlRun "modprobe -r br_netfilter" 0 "disable from bridge call iptables 4/6"
+	(uname -r |grep el6) || rlRun "modprobe -r br_netfilter" 0-255 "disable from bridge call iptables 4/6"
     rlPhaseEnd
 
     rlPhaseStartTest "Regression test for Bug 518034"


### PR DESCRIPTION
If br_netfilter is not loaded, the modprobe -r would fail.
Remove the return value check as we don't care about the result.

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>