### PR TITLE
update test duration to 20 minutes

### DIFF
--- a/distribution/kernel-debuginfo/Makefile
+++ b/distribution/kernel-debuginfo/Makefile
@@ -44,7 +44,7 @@ $(METADATA): Makefile
 	@echo "Path:            /tmp/" >> $(METADATA)
 	@echo "Description:     Ensure that debuginfo vmlinux comes with .debug* sections." >> $(METADATA)
 	@echo "Type:            Misc" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
+	@echo "TestTime:        20m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Requires:        kmod" >> $(METADATA)


### PR DESCRIPTION
Update test duration to 20 minutes as it can run slower on guest machines and time out.