### PR TITLE
blktests: update for RHEL7.2.z/7.3.z/7.4.z/7.5.z

### DIFF
--- a/storage/blk/runtest.sh
+++ b/storage/blk/runtest.sh
@@ -126,10 +126,12 @@ function get_test_cases_block
 		#      - block/026
 		#      - block/028
 		#
-		testcases+=" block/001"
+		# Disable block/001 for RHEL7.2/7.3/7.4/7.5
+		uname -ri | grep -qE "3.10.0-327|3.10.0-514|3.10.0-693|3.10.0-862" || testcases+=" block/001"
 		#testcases+=" block/002" # Test case issue: https://lore.kernel.org/linux-block/e84b29e1-209e-d598-0828-bed5e3b98093@acm.org/
 		#testcases+=" block/009" # Fail randomly on x86_64, powerpc
-		testcases+=" block/016"
+		# block/016 failed on RHEL7.5
+		uname -ri | grep -qE "3.10.0-862" || testcases+=" block/016"
 		#testcases+=" block/020" # Fail randomly on arm64, powerpc
 		testcases+=" block/021"
 		testcases+=" block/023"
@@ -213,6 +215,8 @@ function get_test_cases_nvme
 		uname -ri | grep -qE "3.10.0-.*ppc64$" || testcases+=" nvme/016"
 		testcases+=" nvme/019"
 		testcases+=" nvme/023"
+		uname -ri | grep -qE "3.10.0-327|3.10.0-514|3.10.0-693" && testcases=""
+		uname -ri | grep -qE "3.10.0-862" && testcases=" nvme/006"
 	else
 		#testcases+=" nvme/002" #disable
 		#testcases+=" nvme/003" #disable


### PR DESCRIPTION
RHEL-7.2.z/7.3.z/7.4.z:
block/016 block/021 block/023 loop/001 loop/003 loop/005 loop/006
RHEL-7.5.z:
block/021 block/023 loop/001 loop/003 loop/005 loop/006 nvme/006

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>