### PR TITLE
FMK#1071 : storage san device stress test fails on 7.4.z kernel

### DIFF
--- a/storage/hba/san-device-stress/Makefile
+++ b/storage/hba/san-device-stress/Makefile
@@ -62,6 +62,7 @@ $(METADATA): Makefile
 	@echo "Requires:        libaio-devel" >> $(METADATA)
 	@echo "Requires:        zlib-devel" >> $(METADATA)
 	@echo "Requires:        gcc" >> $(METADATA)
+	@echo "Requires:        git" >> $(METADATA)
 	@echo "RhtsRequires:	hba" >> $(METADATA)
 
 	rhts-lint $(METADATA)


### PR DESCRIPTION
Added a function `fio_setup()` to install fio command via its source code if fio is not found on 7.4.z kernel. (BTW, some useless code lines are removed from `main.sh` for better readability.)