### PR TITLE
IOMMU boot test

### DIFF
--- a/iommu/boot/Makefile
+++ b/iommu/boot/Makefile
@@ -1,0 +1,46 @@
+# Include Common Makefile
+include /usr/share/rhts/lib/rhts-make.include
+
+# The toplevel namespace within which the test lives.
+TOPLEVEL_NAMESPACE=/kernel
+
+RELATIVE_PATH=iommu/boot
+
+# The version of the test rpm that gets created / submitted.
+export TESTVERSION=1.0
+
+# The relative path name to the test.
+export TEST=$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
+
+.PHONY: build clean run
+
+# All files you want bundled into your rpm.
+FILES=	$(METADATA) runtest.sh \
+	Makefile \
+        PURPOSE \
+	default-boot-options-intel.txt \
+	default-boot-options-amd.txt \
+	iommu-dmesg-errors.txt
+
+build:	$(METADATA)
+	chmod a+x ./runtest.sh
+
+clean:
+	rm -f $(METADATA)
+
+run:	build
+	./runtest.sh
+
+$(METADATA):
+	touch $(METADATA)
+	@echo "Name:		$(TEST)" >$(METADATA)
+	@echo "Description:	boot kernel with different iommu options" \
+				>>$(METADATA)
+	@echo "Path:		$(TEST_DIR)" >>$(METADATA)
+	@echo "TestTime:	1h" >>$(METADATA)
+	@echo "TestVersion:	$(TESTVERSION)"	>>$(METADATA)
+	@echo "Destructive:	no" >>$(METADATA)
+	@echo "Confidential:	no" >>$(METADATA)
+	@echo "RunFor:		kernel"	>>$(METADATA)
+	@echo "License:		GPLv2" >>$(METADATA)
+	@echo "Owner:		William Gomeringer <wgomerin@redhat.com>" >>$(METADATA)

--- a/iommu/boot/PURPOSE
+++ b/iommu/boot/PURPOSE
@@ -1,0 +1,13 @@
+This tests booting with various iommu kernel boot options, especially
+ones that are known to cause issues booting like in BZ 908744. The
+code is based on /kernel/cmdline
+
+By default it uses a test included file with different boot options
+'default-boot-options-{intel,amd}.txt' depending on whether the system
+has an AMD or Intel processor. However you can override these if you pass
+in CMDLINEARGS. Separate different boot options or sets of boot
+options with a ":". For example:
+
+CMDLINEARGS="intel_iommu=on"
+or
+CMDLINEARGS="intel_iommu=on iommu=pt:intel_iommu=on,pt64:iommu=on" 

--- a/iommu/boot/default-boot-options-amd.txt
+++ b/iommu/boot/default-boot-options-amd.txt
@@ -1,0 +1,5 @@
+amd_iommu=on
+amd_iommu=on iommu=pt
+amd_iommu=on,isolate
+amd_iommu=on,share
+amd_iommu=on,fullflush

--- a/iommu/boot/default-boot-options-intel.txt
+++ b/iommu/boot/default-boot-options-intel.txt
@@ -1,0 +1,4 @@
+intel_iommu=on
+intel_iommu=on iommu=pt
+intel_iommu=on,pt64
+intel_iommu=on,forcedac,pt64

--- a/iommu/boot/iommu-dmesg-errors.txt
+++ b/iommu/boot/iommu-dmesg-errors.txt
@@ -1,0 +1,13 @@
+Please enable the IOMMU option in the BIOS setup
+AMD-Vi: Event logged \[IO_PAGE_FAULT
+DMAR:\[DMA Read\] Request device \[.*\] fault addr
+DMAR:\[.*\] PTE Write access is not set
+DMAR:\[.*\] PTE Read access is not set
+DMAR:\[.*\] Present bit in context entry is clear
+DRHD: handling fault status reg .*
+DMAR: parse DMAR table failure.
+DMAR reported at address .* returns all ones
+WARNING: at drivers/pci/dmar.c
+Your BIOS is broken; DMAR reported at address zero!
+WARNING: at drivers/pci/intel-iommu.c
+Calgary: DMA error on Calgary PHB

--- a/iommu/boot/runtest.sh
+++ b/iommu/boot/runtest.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# vim: dict=/usr/share/rhts-library/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /kernel/iommu/boot
+#   Description: Test various IOMMU boot options
+#   Author: William Gomeringer <wgomerin@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include rhts environment. Comment out for now while testing script
+. /usr/bin/rhts-environment.sh
+. /usr/share/rhts-library/rhtslib.sh
+
+# file to write custom boot options (from CMDLINEARGS)
+CustomBootOptions=custom-boot-options.txt
+# file to use if no custom boot options passed
+DefaultBootOptionsIntel=default-boot-options-intel.txt
+DefaultBootOptionsAMD=default-boot-options-amd.txt
+# file to store current boot options being tested
+CurrentBootOptions=current-boot-options.txt
+cpuvendor=$(grep -m1 vendor_id /proc/cpuinfo | awk '{print $NF}')
+dmesgErrors=iommu-dmesg-errors.txt
+dmesgReport=iommu-dmesg-report.txt
+
+function bootOptions() {
+    bootOptionsFile=$1
+    
+
+    while read -r line; do
+        # Check to see if new options have been set yet
+	if [[ -z "${REBOOTCOUNT}" ||  "${REBOOTCOUNT}" -eq 0 ]] || \
+	    [[ ! -a $CurrentBootOptions ]]; then
+	    echo "Start test." | tee -a "${OUTPUTFILE}"
+	    echo "Old cmdline: $(cat /proc/cmdline)" | tee -a "${OUTPUTFILE}"
+
+            # Update the boot loader.
+	    default=$(/sbin/grubby --default-kernel)
+
+	    echo "Cmdline to be added: ${line}" | tee -a "${OUTPUTFILE}"
+	    /sbin/grubby --args="${line}" --update-kernel="${default}"
+	    code=$?
+
+	    if [ ${code} -ne 0 ]; then
+		echo "Fail: error changing boot loader." |
+		tee -a "${OUTPUTFILE}"
+		report_result "${TEST}/boot_loader" "FAIL" 0
+	    else
+		echo "${line}" > $CurrentBootOptions
+		echo "Reboot now!" | tee -a "${OUTPUTFILE}"
+		report_result "${TEST}/boot_loader" "PASS" 0
+		rhts-reboot
+	    fi
+	else
+            # The reboot has finished. Verify the cmdline.
+	    echo "New cmdline: $(cat /proc/cmdline)" | tee -a "${OUTPUTFILE}"
+
+            grep "$(cat $CurrentBootOptions)" /proc/cmdline
+	    code=$?
+	    # remove spaces for reporting boot option to beaker
+	    CurrentBootOptionsReport=$(cat $CurrentBootOptions | sed 's/\ /-/')	    
+
+	    if [ ${code} -ne 0 ]; then
+		echo "Fail: error booting kernel with specified cmdline" |
+		tee -a "${OUTPUTFILE}"
+
+		report_result "${TEST}/$CurrentBootOptionsReport" "FAIL" 0
+		rm $CurrentBootOptions
+	        /sbin/grubby --remove-args="${line}" \
+		 --update-kernel="${default}"
+        	sed -i "/$line\$/d" $bootOptionsFile
+	    else
+       		echo "boot options persisted through reboot." | tee -a "${OUTPUTFILE}"
+		report_result "${TEST}/$CurrentBootOptionsReport" "PASS" 0
+	        rm $CurrentBootOptions
+                /sbin/grubby --remove-args="${line}" \
+                 --update-kernel="${default}"
+        	sed -i "/$line\$/d" $bootOptionsFile
+	    fi
+	fi
+
+
+
+    done < $bootOptionsFile
+}
+
+function dmesgErrors() {
+    dmesgLineNumber=0
+    
+    # find any iommu errors in dmesg/messages file
+    while read -r dmesgLine; do
+	dmesgLineNumber=$(($dmesgLineNumber+1))
+	grep "$dmesgLine" /var/log/messages
+	    code=$?
+	    if [ ${code} -ne 1 ]; then
+		echo "Fail: the following iommu regex matched in dmesg:" |
+		tee -a "${OUTPUTFILE}"
+		echo "$dmesgLine" | tee -a "${OUTPUTFILE}"
+		echo "see TESTOUT.log for actual message or $dmesgReport for report" |
+		tee -a "${OUTPUTFILE}"
+		echo "$dmesgLineNumber FAIL $dmesgLine" >> $dmesgReport
+	    else
+		echo "$dmesgLineNumber PASS $dmesgLine" >> $dmesgReport
+	    fi
+    done < $dmesgErrors
+
+    # report pass/fail to beaker if errors were found, upload report
+    grep FAIL $dmesgReport
+    dmesgReportCode=$?
+
+    if [ ${dmesgReportCode} -ne 1 ]; then
+	report_result "${TEST}/iommu-dmesg" "FAIL" 0
+    else
+	report_result "${TEST}/iommu-dmesg" "PASS" 0
+    fi
+    
+    rhts-submit-log -l $dmesgReport
+
+}
+
+function cleanupTest() {
+    rm $dmesgReport
+}
+
+if [[ -n $CMDLINEARGS ]]; then
+    if [ -z "${REBOOTCOUNT}" ] || [ "${REBOOTCOUNT}" -eq 0 ]; then
+       IFS=':'
+       for i in $CMDLINEARGS; do
+	   echo $i >> $CustomBootOptions
+       done
+    fi
+    bootOptions $CustomBootOptions
+    dmesgErrors
+else
+    if [[ $cpuvendor = "GenuineIntel" ]]; then
+	bootOptions $DefaultBootOptionsIntel
+	dmesgErrors
+    elif [[ $cpuvendor = "AuthenticAMD" ]]; then
+       	bootOptions $DefaultBootOptionsAMD
+	dmesgErrors
+    else
+	report_result "${TEST}/nonAMDorIntelProcessor" "FAIL" 0
+    fi
+fi
+
+cleanupTest

--- a/iommu/boot/runtest.sh
+++ b/iommu/boot/runtest.sh
@@ -108,7 +108,7 @@ function dmesgErrors() {
     # find any iommu errors in dmesg/messages file
     while read -r dmesgLine; do
 	dmesgLineNumber=$(($dmesgLineNumber+1))
-	grep "$dmesgLine" /var/log/messages
+	journalctl | grep "$dmesgLine"
 	    code=$?
 	    if [ ${code} -ne 1 ]; then
 		echo "Fail: the following iommu regex matched in dmesg:" |

--- a/iommu/boot/runtest.sh
+++ b/iommu/boot/runtest.sh
@@ -157,7 +157,7 @@ else
        	bootOptions $DefaultBootOptionsAMD
 	dmesgErrors
     else
-	report_result "${TEST}/nonAMDorIntelProcessor" "FAIL" 0
+	report_result "${TEST}/nonAMDorIntelProcessor" "SKIP" 0
     fi
 fi
 


### PR DESCRIPTION
Add a IOMMU boot test with different parameters. It works on RHEL8, RHEL7, and Fedora 30 at least. It will have to be adapted to work on older RHEL releases due to the use of `journalctl`, though.