### PR TITLE
vm/kvm-unit-tests: Increase the timeout for the sieve test for s390x and update the git commit used.

### DIFF
--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -138,7 +138,7 @@ echo 0 > /proc/sys/kernel/nmi_watchdog
 # clone the upstream kvm-unit-tests
 git clone git://git.kernel.org/pub/scm/virt/kvm/kvm-unit-tests.git
 cd kvm-unit-tests
-git checkout 6574705608f8431df465f8417658ffc00ca4d1b6
+git checkout dc9841d08fa1796420a64ad5d5ef652de337809d
 if [ $? -ne 0 ]; then
     echo "Failed to clone and checkout commit from kvm-unit-tests" | tee -a $OUTPUTFILE
     report_result $TEST WARN
@@ -148,6 +148,7 @@ fi
 # update unittests.cfg to exclude known failures
 cp ../x86_unittests.cfg x86/unittests.cfg
 cp ../aarch64_unittests.cfg arm/unittests.cfg
+cp ../s390x_unittests.cfg s390x/unittests.cfg
 
 # run the tests
 if [[ $hwpf == "ppc64" || $hwpf == "ppc64le" ]]; then

--- a/vm/kvm-unit-tests/s390x_unittests.cfg
+++ b/vm/kvm-unit-tests/s390x_unittests.cfg
@@ -1,0 +1,63 @@
+##############################################################################
+# unittest configuration
+#
+# [unittest_name]
+# file = <name>.elf		# Name of the elf file to be used.
+# extra_params = -append <params...>	# Additional parameters used.
+# groups = <group_name1> <group_name2> ... # Used to identify test cases
+#					   # with run_tests -g ...
+#					   # Specify group_name=nodefault
+#					   # to have test not run by default
+# accel = kvm|tcg		# Optionally specify if test must run with
+#				# kvm or tcg. If not specified, then kvm will
+#				# be used when available.
+# timeout = <duration>		# Optionally specify a timeout.
+# check = <path>=<value> # check a file for a particular value before running
+#			 # a test. The check line can contain multiple files
+#			 # to check separated by a space but each check
+#			 # parameter needs to be of the form <path>=<value>
+##############################################################################
+
+[selftest-setup]
+file = selftest.elf
+groups = selftest
+extra_params = -append 'test 123'
+
+[intercept]
+file = intercept.elf
+
+[emulator]
+file = emulator.elf
+
+[sieve]
+file = sieve.elf
+groups = selftest
+# can take fairly long when KVM is nested inside z/VM
+timeout = 1200
+
+[sthyi]
+file = sthyi.elf
+
+[skey]
+file = skey.elf
+
+[diag10]
+file = diag10.elf
+
+[diag308]
+file = diag308.elf
+
+[pfmf]
+file = pfmf.elf
+
+[cmm]
+file = cmm.elf
+
+[vector]
+file = vector.elf
+
+[gs]
+file = gs.elf
+
+[iep]
+file = iep.elf


### PR DESCRIPTION
The sieve test has been failing randomly due to a timeout. This is caused by using zVM configuration (which is slower) instead LPAR for s390x systems.
Updated the commit used for the KVM Unit Tests git repository.