### PR TITLE
networking: clean up dummy interface after bridge test

### DIFF
--- a/networking/bridge/sanity_check/runtest.sh
+++ b/networking/bridge/sanity_check/runtest.sh
@@ -259,6 +259,8 @@ fi
 
     rlPhaseStartCleanup
         rlRun "reset_network_env"
+        rlRun "ip link del dummy0" "0-255"
+        rlRun "modprobe -r dummy" "0-255"
         check_call_trace
     rlPhaseEnd
 rlJournalPrintText


### PR DESCRIPTION
remaining dummy interface would cause driver-sanity fail, so clean up dummy used in bridge test