### PR TITLE
cpu/idle: use epel to install msr-tools on RHEL7

### DIFF
--- a/cpu/idle/Makefile
+++ b/cpu/idle/Makefile
@@ -59,6 +59,7 @@ $(METADATA): Makefile
 	@echo "Requires:     bc" >> $(METADATA)
 	@echo "Requires:     python2-lxml" >> $(METADATA)
 	@echo "Requires:     python3-lxml" >> $(METADATA)
+	@echo "RepoRequires: cki_lib" >> $(METADATA)
 	@echo "RepoRequires: cpu/common" >> $(METADATA)
 	@echo "Priority:     Normal" >> $(METADATA)
 	@echo "License:      GPLv2 or above" >> $(METADATA)


### PR DESCRIPTION
automake of the intel tree does not work.