### PR TITLE
Make kpkginstall more friendly to people outside CKI

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -x
-
 
 . /usr/bin/rhts_environment.sh
 

--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -108,30 +108,30 @@ function get_kpkg_ver()
 function targz_install()
 {
   declare -r kpkg=${KPKG_URL##*/}
-  echo "Fetching kpkg from ${KPKG_URL}" | tee -a ${OUTPUTFILE}
-  curl -OL "${KPKG_URL}" 2>&1 | tee -a ${OUTPUTFILE}
+  echo "Fetching kpkg from ${KPKG_URL}"
+  curl -OL "${KPKG_URL}" 2>&1
 
   if [ $? -ne 0 ]; then
-    echo "Failed to fetch package from ${KPKG_URL}" | tee -a ${OUTPUTFILE}
+    echo "Failed to fetch package from ${KPKG_URL}"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
   fi
 
-  echo "Extracting kernel version from ${KPKG_URL}" | tee -a ${OUTPUTFILE}
+  echo "Extracting kernel version from ${KPKG_URL}"
   get_kpkg_ver
   if [ -z "${KVER}" ]; then
-    echo "Failed to extract kernel version from the package" | tee -a ${OUTPUTFILE}
+    echo "Failed to extract kernel version from the package"
     rhts-abort -t recipe
     exit 1
   else
-    echo "Kernel version is ${KVER}" | tee -a ${OUTPUTFILE}
+    echo "Kernel version is ${KVER}"
   fi
 
-  tar xfh ${kpkg} -C / 2>&1 | tee -a ${OUTPUTFILE}
+  tar xfh ${kpkg} -C / 2>&1
 
   if [ $? -ne 0 ]; then
-    echo "Failed to extract package ${kpkg}" | tee -a ${OUTPUTFILE}
+    echo "Failed to extract package ${kpkg}"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
@@ -184,10 +184,10 @@ function targz_install()
   esac
 
   if [ ! -x /sbin/new-kernel-pkg ]; then
-    kernel-install add ${KVER} /boot/vmlinuz-${KVER} 2>&1 | tee -a ${OUTPUTFILE}
-    grubby --set-default /boot/vmlinuz-${KVER} 2>&1 | tee -a ${OUTPUTFILE}
+    kernel-install add ${KVER} /boot/vmlinuz-${KVER} 2>&1
+    grubby --set-default /boot/vmlinuz-${KVER} 2>&1
   else
-    new-kernel-pkg -v --mkinitrd --dracut --depmod --make-default --host-only --install ${KVER} 2>&1 | tee -a ${OUTPUTFILE}
+    new-kernel-pkg -v --mkinitrd --dracut --depmod --make-default --host-only --install ${KVER} 2>&1
   fi
 
   # Workaround for kernel-install problem when it's not sourcing os-release
@@ -197,7 +197,7 @@ function targz_install()
       # code on BLS systems and when this file exists, to prevent weird failures.
       for f in /boot/loader/entries/*"${KVER}".conf ; do
         title=$(grep title "${f}" | sed "s/[[:space:]]*$//")
-        echo "Removing trailing whitespace in title record of $f" | tee -a ${OUTPUTFILE}
+        echo "Removing trailing whitespace in title record of $f"
         sed -i "s/title.*/$title/" "${f}"
       done
   fi
@@ -214,7 +214,7 @@ function select_yum_tool()
     ALL="all"
     ${YUM} install -y yum-plugin-copr
   else
-    echo "No tool to download kernel from a repo" | tee -a ${OUTPUTFILE}
+    echo "No tool to download kernel from a repo"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
@@ -234,8 +234,8 @@ baseurl=${KPKG_URL}
 enabled=1
 gpgcheck=0
 EOF
-  echo "Setup kernel repo file" | tee -a  ${OUTPUTFILE}
-  cat /etc/yum.repos.d/kernel-cki.repo 2>&1 | tee -a ${OUTPUTFILE}
+  echo "Setup kernel repo file"
+  cat /etc/yum.repos.d/kernel-cki.repo 2>&1
 
   return 0
 }
@@ -247,7 +247,7 @@ function copr_prepare()
 
   ${YUM} copr enable -y "${KPKG_URL}"
   if [ $? -ne 0 ]; then
-    echo "Can't enable COPR repo!" | tee -a ${OUTPUTFILE}
+    echo "Can't enable COPR repo!"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
   fi
@@ -256,11 +256,11 @@ function copr_prepare()
 
 function download_install_package()
 {
-  $YUM install --downloadonly -y $1 2>&1 | tee -a ${OUTPUTFILE}
+  $YUM install --downloadonly -y $1 2>&1
 
   # If download of a package fails, report warn/abort -> infrastructure issue
   if [ $? -ne 0 ]; then
-    echo "Failed to download $2!" 2>&1 | tee -a ${OUTPUTFILE}
+    echo "Failed to download $2!" 2>&1
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
@@ -269,9 +269,9 @@ function download_install_package()
   # If installation of a downloaded package fails, report fail/abort
   # -> distro issue
 
-  $YUM install -y $1 2>&1 | tee -a ${OUTPUTFILE}
+  $YUM install -y $1 2>&1
   if [ $? -ne 0 ]; then
-    echo "Failed to install $2!" | tee -a ${OUTPUTFILE}
+    echo "Failed to install $2!"
     report_result ${TEST} FAIL 1
     rhts-abort -t recipe
     exit 1
@@ -280,15 +280,15 @@ function download_install_package()
 
 function rpm_install()
 {
-  echo "Extracting kernel version from ${KPKG_URL}" | tee -a ${OUTPUTFILE}
+  echo "Extracting kernel version from ${KPKG_URL}"
   get_kpkg_ver
   if [ -z "${KVER}" ]; then
-    echo "Failed to extract kernel version from the package" | tee -a ${OUTPUTFILE}
+    echo "Failed to extract kernel version from the package"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
   else
-    echo "Kernel version is ${KVER}" | tee -a ${OUTPUTFILE}
+    echo "Kernel version is ${KVER}"
   fi
 
   # Ensure that the debug kernel is selected as the default kernel in
@@ -303,21 +303,21 @@ function rpm_install()
   # download & install kernel, or report result
   download_install_package "${PACKAGE_NAME}-$KVER" "kernel"
 
-  $YUM install -y "${PACKAGE_NAME}-devel-${KVER}" 2>&1 | tee -a ${OUTPUTFILE}
+  $YUM install -y "${PACKAGE_NAME}-devel-${KVER}" 2>&1
   if [ $? -ne 0 ]; then
-    echo "No package kernel-devel-${KVER} found, skipping!" | tee -a ${OUTPUTFILE}
-    echo "Note that some tests might require the package and can fail!" | tee -a ${OUTPUTFILE}
+    echo "No package kernel-devel-${KVER} found, skipping!"
+    echo "Note that some tests might require the package and can fail!"
   fi
-  $YUM install -y "${PACKAGE_NAME}-headers-${KVER}" 2>&1 | tee -a ${OUTPUTFILE}
+  $YUM install -y "${PACKAGE_NAME}-headers-${KVER}" 2>&1
   if [ $? -ne 0 ]; then
-    echo "No package kernel-headers-${KVER} found, skipping!" | tee -a ${OUTPUTFILE}
+    echo "No package kernel-headers-${KVER} found, skipping!"
   fi
 
   # The package was renamed (and temporarily aliased) in Fedora/RHEL
   if $YUM search kernel-firmware | grep "^kernel-firmware\.noarch" ; then
-      $YUM install -y kernel-firmware 2>&1 | tee -a ${OUTPUTFILE}
+      $YUM install -y kernel-firmware 2>&1
   else
-      $YUM install -y linux-firmware 2>&1 | tee -a ${OUTPUTFILE}
+      $YUM install -y linux-firmware 2>&1
   fi
 
   # Workaround for BZ 1698363
@@ -344,7 +344,7 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
   fi
 
   if [ -z "${KPKG_URL}" ]; then
-    echo "No KPKG_URL specified" | tee -a ${OUTPUTFILE}
+    echo "No KPKG_URL specified"
     rhts-abort -t recipe
     exit 1
   fi
@@ -362,13 +362,13 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
   fi
 
   if [ $? -ne 0 ]; then
-    echo "Failed installing kernel ${KVER}" | tee -a ${OUTPUTFILE}
+    echo "Failed installing kernel ${KVER}"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
   fi
 
-  echo "Installed kernel ${KVER}, rebooting" | tee -a ${OUTPUTFILE}
+  echo "Installed kernel ${KVER}, rebooting"
   report_result ${TEST}/kernel-in-place PASS 0
   rhts-reboot
 else
@@ -378,16 +378,16 @@ else
   if [[ ! "${KPKG_URL}" =~ .*\.tar\.gz ]] ; then
     set_package_name
   fi
-  echo "Extracting kernel version from ${KPKG_URL}" | tee -a ${OUTPUTFILE}
+  echo "Extracting kernel version from ${KPKG_URL}"
   get_kpkg_ver
   if [ -z "${KVER}" ]; then
-    echo "Failed to extract kernel version from the package" | tee -a ${OUTPUTFILE}
+    echo "Failed to extract kernel version from the package"
     rhts-abort -t recipe
     exit 1
   fi
 
   ckver=$(uname -r)
-  uname -a | tee -a ${OUTPUTFILE}
+  uname -a
 
   # Make a list of kernel versions we expect to see after reboot.
   if [ -f /tmp/kpkginstall/KPKG_INSTALL_DEBUG ]; then
@@ -408,7 +408,7 @@ else
 
   # Did we get the right kernel running after reboot?
   if [[ ! " ${valid_kernel_versions[@]} " =~ " ${ckver} " ]]; then
-    echo "❌ Kernel version after reboot (${ckver}) does not match expected version strings!" | tee -a ${OUTPUTFILE}
+    echo "❌ Kernel version after reboot (${ckver}) does not match expected version strings!"
     report_result ${TEST} WARN 99
     rhts-abort -t recipe
     exit 0
@@ -423,7 +423,7 @@ else
     DMESGLOG=/tmp/dmesg.log
     dmesg > ${DMESGLOG}
     rhts_submit_log -l ${DMESGLOG}
-    echo "⚠️  Call trace found in dmesg, see dmesg.log" | tee -a ${OUTPUTFILE}
+    echo "⚠️  Call trace found in dmesg, see dmesg.log"
     report_result ${TEST} WARN 7
   else
     report_result ${TEST}/reboot PASS 0

--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -19,6 +19,7 @@ function set_package_name()
   # Recover the saved package name from /tmp/KPKG_PACKAGE_NAME if it exists.
   if [ -f "/tmp/kpkginstall/KPKG_PACKAGE_NAME" ]; then
     PACKAGE_NAME=$(cat /tmp/kpkginstall/KPKG_PACKAGE_NAME)
+    echo "Reading cached package name: ${PACKAGE_NAME}"
     return
   fi
 
@@ -30,6 +31,7 @@ function set_package_name()
     REPO_NAME='kernel-cki'
   fi
 
+  echo "Getting a list of all packages in the repository..."
   ALL_PACKAGES=$(${YUM} -q --disablerepo="*" --enablerepo="${REPO_NAME}" list "${ALL}" --showduplicates | tr "\n" "#" | sed -e 's/# / /g' | tr "#" "\n" | grep "^kernel.*\.$ARCH.*${REPO_NAME}")
 
   # An empty result for ALL_PACKAGES likely means that the repo has been
@@ -52,11 +54,13 @@ EOF
 
   for possible_name in "kernel-rt" ; do
     if echo "$ALL_PACKAGES" | grep $possible_name ; then
+      echo "📦 Found 'kernel-rt' in package list"
       PACKAGE_NAME=$possible_name
       break
     fi
   done
   if [[ -z $PACKAGE_NAME ]] ; then
+      echo "📦 Found 'kernel' in package list"
       PACKAGE_NAME=kernel
   fi
 
@@ -67,9 +71,10 @@ EOF
   fi
 
   # Write the PACKAGE_NAME to a file in /tmp so we have it after reboot.
+  echo "💾 Saving package name to disk..."
   echo -n "${PACKAGE_NAME}" | tee -a /tmp/kpkginstall/KPKG_PACKAGE_NAME
 
-  echo "Package name is ${PACKAGE_NAME}" | tee -a ${OUTPUTFILE}
+  echo "📦 Package name is ${PACKAGE_NAME}"
 }
 
 function get_kpkg_ver()

--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -82,6 +82,7 @@ function get_kpkg_ver()
   # Recover the saved package name from /tmp/KPKG_KVER if it exists.
   if [ -f "/tmp/kpkginstall/KPKG_KVER" ]; then
     KVER=$(cat /tmp/kpkginstall/KPKG_KVER)
+    echo "💾 Reading cached kernel package version: ${KPKG}"
     return
   fi
 
@@ -106,7 +107,10 @@ function get_kpkg_ver()
     )
   fi
 
+  echo "📦 Setting kernel package version: ${KVER}"
+
   # Write the KVER to a file in /tmp so we have it after reboot.
+  echo "💾 Saving kernel package version to disk..."
   echo -n "${KVER}" | tee -a /tmp/kpkginstall/KPKG_KVER
 }
 


### PR DESCRIPTION
The output from `kpkginstall` is incredibly verbose and it's confusing to know exactly what broke when something goes wrong. This PR aims to make the output easier to read and remove that dreaded `set -x`.

⚠️ **THIS IS CURRENTLY A WIP PR.** ⚠️