### PR TITLE
Make kpkginstall messages friendly

### DIFF
--- a/cki_lib/lib.sh
+++ b/cki_lib/lib.sh
@@ -35,3 +35,20 @@ function cki_yum_tool()
   fi
 }
 
+function print_info()
+{
+  # Print an informational message with a friendly emoji.
+  echo "ℹ️ ${1}"
+}
+
+function print_success()
+{
+  # Print a success message with a friendly emoji.
+  echo "✅ ${1}"
+}
+
+function print_warning()
+{
+  # Print an warning message with a friendly emoji.
+  echo "⚠️ ${1}"
+}


### PR DESCRIPTION
The kpkginstall output is highly cluttered and confusing to people outside
the CKI group.

Add simple functions for printing messages with different statuses and use
those throughout the script. Also, remove `-x` from the script to reduce
clutter in the output.

Signed-off-by: Major Hayden <major@redhat.com>