### PR TITLE
Refactor yum/dnf installation

### DIFF
--- a/distribution/kpkginstall/Makefile
+++ b/distribution/kpkginstall/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Red Hat, Inc. All rights reserved. This copyrighted material 
+# Copyright (c) 2014 Red Hat, Inc. All rights reserved. This copyrighted material
 # is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2.
@@ -47,5 +47,4 @@ $(METADATA): Makefile
 	@echo "License:         GPL" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Requires:        $(PACKAGE_NAME) make curl grubby tar binutils" >> $(METADATA)
 	@echo "RepoRequires:    cki_lib" >> $(METADATA)


### PR DESCRIPTION
Installing packages with restraint's installer sometimes takes 2-5 minutes
due to lots of dnf retries. Instead, move the packages into the
`select_yum_tool()` function and use basic yum/dnf commands to install
the packages.

Signed-off-by: Major Hayden <major@redhat.com>