### PR TITLE
FMK-1038 : Enable /kernel/storage/dm/common test in kpet-db

### DIFF
--- a/storage/dm/common/Makefile
+++ b/storage/dm/common/Makefile
@@ -1,0 +1,54 @@
+TOPLEVEL_NAMESPACE	= kernel
+PACKAGE_NAME		= kernel
+RELATIVE_PATH		= storage/dm/common
+
+export TEST=/$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
+export TESTVERSION=1.0
+
+.PHONY: all install download clean
+
+BUILT_FILES	= runtest
+
+FILES		= $(METADATA) \
+		  Makefile \
+		  README.md \
+		  PURPOSE \
+		  runtest.sh
+
+run: $(FILES) build
+	./runtest
+
+runtest: runtest.sh
+	cp $< $@ && chmod +x $@
+
+build: $(BUILT_FILES)
+
+clean:
+	rm -f *~ *.rpm $(BUILT_FILES)
+
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:        Jakub Krysl <jkrysl@redhat.com>" > $(METADATA)
+	@echo "Name:         $(TEST)" >> $(METADATA)
+	@echo "TestVersion:  $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:  Tests device-mapper, mainly Core">> $(METADATA)
+	@echo "TestTime:     1h" >> $(METADATA)
+	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
+	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
+	@echo "Requires:     git" >> $(METADATA)
+	@echo "Requires:     wget" >> $(METADATA)
+	@echo "Requires:     augeas" >> $(METADATA)
+	@echo "Requires:     python3" >> $(METADATA)
+	@echo "Requires:     python2-lxml" >> $(METADATA)
+	@echo "Requires:     python3-lxml" >> $(METADATA)
+	@echo "RepoRequires: cki_lib" >> $(METADATA)
+	@echo "RepoRequires: storage/include" >> $(METADATA)
+	@echo "Priority:     Normal" >> $(METADATA)
+	@echo "License:      GPLv2 or above" >> $(METADATA)
+	@echo "Confidential: no" >> $(METADATA)
+	@echo "Destructive:  no" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/storage/dm/common/PURPOSE
+++ b/storage/dm/common/PURPOSE
@@ -1,0 +1,32 @@
+#===========================================================================
+#
+# PURPOSE file for:
+#   /kernel/storage/dm/common
+#
+# Description:
+#   Test device-mapper with parameters
+#
+# Bugs related:
+#
+# Author(s):
+#   Jakub Krysl
+#   <jkrysl@redhat.com>
+#
+#===========================================================================
+# Note:
+# As with all DM tests, at the end of the test it will check
+# for errors on the logs.
+# This check is implemented in python-stqe/host/tc
+#
+# To avoid DM tests reporting error that were caused before the test
+# started it is recommended to run /kernel/storage/misc/log_checker
+# just before running the test
+#===========================================================================
+# This task takes optional parameters:
+#    --filter=$FMF_FILTER
+#        examples: --filter='tier:1|tier:2'
+#                  --filter='compose:RHEL-$OS'
+#
+#===========================================================================
+# EndFile
+

--- a/storage/dm/common/README.md
+++ b/storage/dm/common/README.md
@@ -1,0 +1,15 @@
+# storage/dm/common suite
+storage/dm/common provides test for device-mapper with parameters. The source
+code can be found at https://gitlab.com/rh-kernel-stqe/python-stqe.
+Test Maintainer: [Jakub Krysl](mailto:jkrysl@redhat.com)
+
+## How to run it
+
+### Dependencies
+Please refer to the top-level README.md for common dependencies. Test-specific
+dependencies will automatically be installed when executing 'make run'.
+
+### Execute the test
+```bash
+$ make run
+```

--- a/storage/dm/common/runtest.sh
+++ b/storage/dm/common/runtest.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved.
+#
+# This copyrighted material is made available to anyone wishing
+# to use, modify, copy, or redistribute it subject to the terms
+# and conditions of the GNU General Public License version 2.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+FILE=$(readlink -f $BASH_SOURCE)
+NAME=$(basename $FILE)
+CDIR=$(dirname $FILE)
+
+source $CDIR/../../../storage/include/libstqe.sh
+
+function startup
+{
+    stqe_init_fwroot "master"
+}
+
+function cleanup
+{
+    stqe_fini_fwroot
+}
+
+function runtest
+{
+    typeset fwroot=$(stqe_get_fwroot)
+    cki_cd $fwroot
+    cki_run_cmd_pos "stqe-test run --fmf --filter component:device-mapper"
+    typeset -i rc=$?
+    cki_pd
+    (( rc != 0 )) && return $CKI_FAIL || return $CKI_PASS
+}
+
+cki_debug
+cki_main
+exit $?


### PR DESCRIPTION
Currently, it fails when running the case via beaker, but it passes if we run it manually. The test maintainer is helping to figure out why, please hold on to review it until I remove WIP.