### PR TITLE
vm/kvm-unit-tests: Fix a few test issues

### DIFF
--- a/vm/kvm-unit-tests/aarch64_unittests.cfg
+++ b/vm/kvm-unit-tests/aarch64_unittests.cfg
@@ -122,20 +122,19 @@ smp = $MAX_SMP
 extra_params = -machine gic-version=3 -append 'active'
 groups = gic
 
-# Disabled by https://bugzilla.redhat.com/show_bug.cgi?id=1716073 
+# Disabled by https://bugzilla.redhat.com/show_bug.cgi?id=1716073
 # Test PSCI emulation
 #[psci]
 #file = psci.flat
 #smp = $MAX_SMP
 #groups = psci
 
-# Disabled by https://bugzilla.redhat.com/show_bug.cgi?id=1716066
 # Timer tests
-#[timer]
-#file = timer.flat
-#groups = timer
-#timeout = 2s
-#arch = arm64
+[timer]
+file = timer.flat
+groups = timer
+timeout = 2s
+arch = arm64
 
 # Exit tests
 [micro-bench]

--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -79,16 +79,18 @@ else
 fi
 
 KVM_SYSFS=/sys/module/kvm/parameters/
-KVM_OPTIONS_X86="enable_vmware_backdoor force_emulation_prefix"
+KVM_OPTIONS_X86="enable_vmware_backdoor force_emulation_prefix nested"
 
 if [[ $hwpf == "x86_64" ]]; then
     # set the virt kernel parameters
     echo -e "options kvm force_emulation_prefix=1\noptions kvm enable_vmware_backdoor=1" > /etc/modprobe.d/kvm-ci.conf
     # reload the modules
     if (lsmod | grep -q kvm_intel); then
+        echo -e "options kvm_intel nested=1" >> /etc/modprobe.d/kvm-ci.conf
         rmmod kvm_intel kvm
         modprobe kvm_intel kvm
     elif (lsmod | grep -q kvm_amd); then
+        echo -e "options kvm_amd nested=1" >> /etc/modprobe.d/kvm-ci.conf
         rmmod kvm_amd kvm
         modprobe kvm_amd kvm
     fi

--- a/vm/kvm-unit-tests/x86_unittests.cfg
+++ b/vm/kvm-unit-tests/x86_unittests.cfg
@@ -122,16 +122,17 @@ file = pku.flat
 arch = x86_64
 extra_params = -cpu host
 
-# Commented out on upstream
-#[asyncpf]
-#file = asyncpf.flat
+[asyncpf]
+file = asyncpf.flat
+extra_params = -m 2048
 
 [emulator]
 file = emulator.flat
 arch = x86_64
 
-[eventinj]
-file = eventinj.flat
+# RHEL8: Disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1748461
+#[eventinj]
+#file = eventinj.flat
 
 [hypercall]
 file = hypercall.flat
@@ -198,7 +199,8 @@ extra_params = -cpu host
 file = rmap_chain.flat
 arch = x86_64
 
-# Disabled due to: https://bugzilla.redhat.com/show_bug.cgi?id=1716601
+# ARK: Disabled due to: https://bugzilla.redhat.com/show_bug.cgi?id=1716601
+# RHEL8: Disabled due to: https://bugzilla.redhat.com/show_bug.cgi?id=1742756
 #[svm]
 #file = svm.flat
 #smp = 2
@@ -236,25 +238,25 @@ extra_params = -cpu qemu64,+umip
 #arch = x86_64
 #groups = vmx
 
-#[ept]
-#file = vmx.flat
-#extra_params = -cpu host,host-phys-bits,+vmx -m 2560 -append "ept_access*"
-#arch = x86_64
-#groups = vmx
+[ept]
+file = vmx.flat
+extra_params = -cpu host,host-phys-bits,+vmx -m 2560 -append "ept_access*"
+arch = x86_64
+groups = vmx
 
-#[vmx_eoi_bitmap_ioapic_scan]
-#file = vmx.flat
-#smp = 2
-#extra_params = -cpu host,+vmx -m 2048 -append vmx_eoi_bitmap_ioapic_scan_test
-#arch = x86_64
-#groups = vmx
+[vmx_eoi_bitmap_ioapic_scan]
+file = vmx.flat
+smp = 2
+extra_params = -cpu host,+vmx -m 2048 -append vmx_eoi_bitmap_ioapic_scan_test
+arch = x86_64
+groups = vmx
 
-#[vmx_hlt_with_rvi_test]
-#file = vmx.flat
-#extra_params = -cpu host,+vmx -append vmx_hlt_with_rvi_test
-#arch = x86_64
-#groups = vmx
-#timeout = 10
+[vmx_hlt_with_rvi_test]
+file = vmx.flat
+extra_params = -cpu host,+vmx -append vmx_hlt_with_rvi_test
+arch = x86_64
+groups = vmx
+timeout = 10
 
 #[vmx_apicv_test]
 #file = vmx.flat
@@ -263,18 +265,19 @@ extra_params = -cpu qemu64,+umip
 #groups = vmx
 #timeout = 10
 
-#[vmx_apic_passthrough_thread]
-#file = vmx.flat
-#smp = 2
-#extra_params = -cpu host,+vmx -m 2048 -append vmx_apic_passthrough_thread_test
-#arch = x86_64
-#groups = vmx
+[vmx_apic_passthrough_thread]
+file = vmx.flat
+smp = 2
+extra_params = -cpu host,+vmx -m 2048 -append vmx_apic_passthrough_thread_test
+arch = x86_64
+groups = vmx
 
-#[vmx_vmcs_shadow_test]
-#file = vmx.flat
-#extra_params = -cpu host,+vmx -append vmx_vmcs_shadow_test
-#arch = x86_64
-#groups = vmx
+[vmx_vmcs_shadow_test]
+file = vmx.flat
+extra_params = -cpu host,+vmx -append vmx_vmcs_shadow_test
+arch = x86_64
+groups = vmx
+timeout = 180
 
 [debug]
 file = debug.flat


### PR DESCRIPTION
- Re-enable some test. Enable Nested test cases.
- Disable eventinj test that is failing on older Intel processors.
- Increase timeout for vmx_vmcs_shadow_test.