### PR TITLE
add non bare-metal patch and link known issues

### DIFF
--- a/distribution/ltp-upstream/include/knownissue.sh
+++ b/distribution/ltp-upstream/include/knownissue.sh
@@ -133,19 +133,20 @@ function knownissue_filter()
 	tskip "madvise09" fatal
 	# Issue TBD
 	tskip "ksm0.*" fatal
-	# Issue TBD
+	# Issue http://lists.linux.it/pipermail/ltp/2019-August/013267.html
 	tskip "timer_create01" unfix
-	# Issue TBD
+	# Bug 1660161 - [RHEL8] ltp/generic commands mkswap01 fails to create by-UUID device node in aarch64
+	# Issue https://github.com/linux-test-project/ltp/issues/458
 	tskip "mkswap01_sh" unfix
-	# Issue TBD
-	tskip "huge.*" unfix
+	# hugetlb failures should be ignored since that lack of system memory for testing
+	tskip "huge.*" fatal
 	# Issue TBD
 	tskip "read_all_.*" unfix
 	# Issue TBD
 	tskip "memfd_create03" unfix
-	# Issue TBD
+	# https://lore.kernel.org/linux-btrfs/4d97a9bb-864a-edd1-1aff-bdc9c8204100@redhat.com/T/#u 
 	tskip "fs_fill" unfix
-	# Issue TBD
+	# this case always make the beaker task abort with 'incrementing stop' msg
 	tskip "min_free_kbytes" fatal
 	# Issue TBD
 	tskip "msgstress0.*" unfix
@@ -157,6 +158,8 @@ function knownissue_filter()
 	tskip "sync_file_range02" unfix
 	# Issue TBD
 	tskip "signal06" unfix
+	# Issue TBD
+	tskip "statx07" unfix
 
 	if is_rhel8; then
                 # ------- unfix ---------

--- a/distribution/ltp-upstream/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
+++ b/distribution/ltp-upstream/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/tst_timer_test.c b/lib/tst_timer_test.c
+index cd4ebcaa89e0..c08b7cadb385 100644
+--- a/lib/tst_timer_test.c
++++ b/lib/tst_timer_test.c
+@@ -194,7 +194,7 @@ static int cmp(const void *a, const void *b)
+ static long long compute_threshold(long long requested_us,
+ 				   unsigned int nsamples)
+ {
+-	unsigned int slack_per_scall = MIN(100000, requested_us / 1000);
++	unsigned int slack_per_scall = requested_us / 100;
+ 
+ 	slack_per_scall = MAX(slack_per_scall, timerslack);
+ 

--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -72,11 +72,13 @@ function ltp_test_build()
 	fi
 
 	pushd ltp > /dev/null 2>&1
-	git checkout c2049b5c874bc071f8185bffb5fd7dcb042d9ec8
+	git checkout 8b678498cb391d9dc4677bd541e0406cdaf39553
 	make autotools                      &> configlog.txt || if cat configlog.txt; then test_msg fail "config  ltp failed"; fi
 	./configure --prefix=${TARGET_DIR}  &> configlog.txt || if cat configlog.txt; then test_msg fail "config  ltp failed"; fi
 	make -j$CPUS_NUM                    &> buildlog.txt  || if cat buildlog.txt;  then test_msg fail "build   ltp failed"; fi
 	make install                        &> buildlog.txt  || if cat buildlog.txt;  then test_msg fail "install ltp failed"; fi
+	# Timing on systems with shared resources (and high steal time) is not accurate, apply patch for non bare-metal machines
+	patch -p1 < ../patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
 	popd > /dev/null 2>&1
 
 	test_msg pass "LTP build/install successful"


### PR DESCRIPTION
Update to a later commit, link known issues, apply patch for non bare-metal machines as timing on systems with shared resources (and high steal time) is not accurate. See J:3771976 for results, one job failed with an intermittent failure, will continue to monitor it.