### PR TITLE
Add missing wget requirement to loopdev sanity test

### DIFF
--- a/filesystems/loopdev/sanity/Makefile
+++ b/filesystems/loopdev/sanity/Makefile
@@ -70,5 +70,6 @@ $(METADATA):
 	@echo "Requires:	gcc"            >> $(METADATA)
 	@echo "Requires:	make"           >> $(METADATA)
 	@echo "Requires:	glibc-static"   >> $(METADATA)
+	@echo "Requires:	wget"           >> $(METADATA)
 	@echo "Owner:		Jan Stancek <jstancek@redhat.com>" >> $(METADATA)
 	@echo "License:		GPLv2"		>> $(METADATA)


### PR DESCRIPTION
The Makefile for the loopdev sanity test was using wget, but it wasn't in the test requirements. Add it so that the test can run properly.