### PR TITLE
Add rsync dependency to kvm-selftest

### DIFF
--- a/vm/kvm-self-tests/Makefile
+++ b/vm/kvm-self-tests/Makefile
@@ -53,6 +53,7 @@ $(METADATA): Makefile
 	@echo "Requires:        make" >> $(METADATA)
 	@echo "Requires:        gcc" >> $(METADATA)
 	@echo "Requires:        patch" >> $(METADATA)
+	@echo "Requires:	rsync" >> $(METADATA)
 	@echo "Requires:        python2-lxml" >> $(METADATA)
 	@echo "Requires:        python3-lxml" >> $(METADATA)
 	@echo "Requires:        bc" >> $(METADATA)


### PR DESCRIPTION
Add missing rsync dependency for fedora.