### PR TITLE
vm/kvm-unit-tests: Disable tests failing for x86_64 and PPC64.

### DIFF
--- a/vm/kvm-unit-tests/ppc64le_unittests.cfg
+++ b/vm/kvm-unit-tests/ppc64le_unittests.cfg
@@ -1,0 +1,72 @@
+##############################################################################
+# unittest configuration
+#
+# [unittest_name]
+# file = <name>.flat		# Name of the flat file to be used.
+# smp  = <num>			# Number of processors the VM will use
+#				# during this test. Use $MAX_SMP to use
+#				# the maximum the host supports. Defaults
+#				# to one.
+# extra_params = -append <params...>	# Additional parameters used.
+# arch = ppc64				# Select one if the test case is
+#					# specific to only one.
+# groups = <group_name1> <group_name2> ...	# Used to identify test cases
+#						# with run_tests -g ...
+#						# Specify group_name=nodefault
+#						# to have test not run by
+#						# default
+# accel = kvm|tcg		# Optionally specify if test must run with
+#				# kvm or tcg. If not specified, then kvm will
+#				# be used when available.
+# timeout = <duration>		# Optionally specify a timeout.
+# check = <path>=<value> # check a file for a particular value before running
+#                        # a test. The check line can contain multiple files
+#                        # to check separated by a space but each check
+#                        # parameter needs to be of the form <path>=<value>
+##############################################################################
+
+#
+# Test that the configured number of processors (smp = <num>), and
+# that the configured amount of memory (-m <MB>) are correctly setup
+# by the framework.
+#
+[selftest-setup]
+file = selftest.elf
+smp = 2
+extra_params = -m 256 -append 'setup smp=2 mem=256'
+groups = selftest
+
+[spapr_hcall]
+file = spapr_hcall.elf
+
+[rtas-get-time-of-day]
+file = rtas.elf
+timeout = 5
+extra_params = -append "get-time-of-day date=$(date +%s)"
+groups = rtas
+
+[rtas-get-time-of-day-base]
+file = rtas.elf
+timeout = 5
+extra_params = -rtc base="2006-06-17" -append "get-time-of-day date=$(date --date="2006-06-17 UTC" +%s)"
+groups = rtas
+
+[rtas-set-time-of-day]
+file = rtas.elf
+extra_params = -append "set-time-of-day"
+timeout = 5
+groups = rtas
+
+[emulator]
+file = emulator.elf
+
+#[h_cede_tm]
+#file = tm.elf
+#smp = 2,threads=2
+#extra_params = -machine cap-htm=on -append "h_cede_tm"
+#groups = h_cede_tm
+
+[sprs]
+file = sprs.elf
+extra_params = -append '-w'
+groups = migration

--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -167,6 +167,7 @@ fi
 cp ../x86_unittests.cfg x86/unittests.cfg
 cp ../aarch64_unittests.cfg arm/unittests.cfg
 cp ../s390x_unittests.cfg s390x/unittests.cfg
+cp ../ppc64le_unittests.cfg powerpc/unittests.cfg
 
 # run the tests
 if [[ $hwpf == "ppc64" || $hwpf == "ppc64le" ]]; then

--- a/vm/kvm-unit-tests/x86_unittests.cfg
+++ b/vm/kvm-unit-tests/x86_unittests.cfg
@@ -108,10 +108,10 @@ file = vmexit.flat
 groups = vmexit
 extra_params = -cpu qemu64,+x2apic,+tsc-deadline -append tscdeadline_immed
 
-[access]
-file = access.flat
-arch = x86_64
-extra_params = -cpu host
+#[access]
+#file = access.flat
+#arch = x86_64
+#extra_params = -cpu host
 
 [smap]
 file = smap.flat


### PR DESCRIPTION
Disable the access test for x86_64 for failing in Xeon Silver processors.
Disable the h_cede_tm test for PPC64 for failing in 2.3 (pvr 004e 1203) POWER9 processors.