### PR TITLE
ipsec/ipsec_basic_netns: extend the test time and send less tcp data

### DIFF
--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/Makefile
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/Makefile
@@ -71,7 +71,7 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  ipsec/ipsec_basic/ipsec_basic_netns">> $(METADATA)
-	@echo "TestTime:     20m" >> $(METADATA)
+	@echo "TestTime:     40m" >> $(METADATA)
 	@echo "Type:         Function" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here

--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
@@ -78,11 +78,11 @@ data_tests(){
 	ipsec_stat tcp before
 	rlRun "$HB socat -u -$TEST_VER tcp-l:$tcpport open:tcprecv,creat &"
 	rlRun "sleep 1"
-	bytes_10M="10485760" # (10M) for tcp test
-	[ $TEST_VER -eq 4 ] && rlRun "$HA socat -u -4 /dev/zero,readbytes=$bytes_10M tcp-connect:${HB_IP[$TEST_VER]}:$tcpport"
-	[ $TEST_VER -eq 6 ] && rlRun "$HA socat -u -6 /dev/zero,readbytes=$bytes_10M tcp-connect:[${HB_IP[$TEST_VER]}]:$tcpport"
+	bytes_1M="1048576" # (1M) for tcp test
+	[ $TEST_VER -eq 4 ] && rlRun "$HA socat -u -4 /dev/zero,readbytes=$bytes_1M tcp-connect:${HB_IP[$TEST_VER]}:$tcpport"
+	[ $TEST_VER -eq 6 ] && rlRun "$HA socat -u -6 /dev/zero,readbytes=$bytes_1M tcp-connect:[${HB_IP[$TEST_VER]}]:$tcpport"
 	rlRun "sleep 2"
-	rlRun "ls -l tcprecv | grep $bytes_10M" 0 "tcp should receive $bytes_10M bytes, received `ls -l tcprecv | awk '{print $5}'` bytes"
+	rlRun "ls -l tcprecv | grep $bytes_1M" 0 "tcp should receive $bytes_1M bytes, received `ls -l tcprecv | awk '{print $5}'` bytes"
 	rm -f tcprecv
 	ipsec_stat tcp after
 	rlLog "***** udp ******"


### PR DESCRIPTION
commit fbfe522fb40db9d6e1720a5c12d19fa7bfb8e365
Author: Xiumei Mu <xmu@redhat.com>
Date:   Wed Sep 11 16:37:52 2019 +0800

    ipsec/ipsec_basic_netns: extend the test time and send less tcp data

    This fix is for tcp connection fail on some mahines(Mustangs,aach64)

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>