### PR TITLE
patch ltp dynamic_debug grep check

### DIFF
--- a/distribution/ltp-upstream/lite/patches/dynamic_debug_dmesg_check.patch
+++ b/distribution/ltp-upstream/lite/patches/dynamic_debug_dmesg_check.patch
@@ -1,0 +1,13 @@
+diff --git a/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh b/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh
+index f39d67d0a..7f06c2488 100755
+--- a/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh
++++ b/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh
+@@ -127,7 +127,7 @@ ddebug_test()
+        sed -i -e 1,`wc -l < ./dmesg.old`d ./dmesg.new
+        if grep -q -e "Kernel panic" -e "Oops" -e "general protection fault" \
+                -e "general protection handler: wrong gs" -e "\(XEN\) Panic" \
+-               -e "fault" -e "warn" -e "BUG" ./dmesg.new ; then
++               -e "fault" -e "warn" -e "\<BUG\>" ./dmesg.new ; then
+                tst_res TFAIL "Issues found in dmesg!"
+        else
+                tst_res TPASS "Dynamic debug OK"

--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -79,6 +79,8 @@ function ltp_test_build()
 	make install                        &> buildlog.txt  || if cat buildlog.txt;  then test_msg fail "install ltp failed"; fi
 	# Timing on systems with shared resources (and high steal time) is not accurate, apply patch for non bare-metal machines
 	patch -p1 < ../patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
+	# Debug kernels will fail dmesg check when greping for BUG
+	patch -p1 < ../patches/dynamic_debug_dmesg_check.patch
 	popd > /dev/null 2>&1
 
 	test_msg pass "LTP build/install successful"


### PR DESCRIPTION
Now that we test debug kernels, the dynamic_debug01 test will fail the dmesg check when grepping for BUG, patch test to only check for BUG vs DEBUG in logs