### PR TITLE
LTP workaround for oom aborting runtest.sh

### DIFF
--- a/distribution/ltp-upstream/lite/patches/dynamic_debug_dmesg_check.patch
+++ b/distribution/ltp-upstream/lite/patches/dynamic_debug_dmesg_check.patch
@@ -3,11 +3,11 @@ index f39d67d0a..7f06c2488 100755
 --- a/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh
 +++ b/testcases/kernel/tracing/dynamic_debug/dynamic_debug01.sh
 @@ -127,7 +127,7 @@ ddebug_test()
-        sed -i -e 1,`wc -l < ./dmesg.old`d ./dmesg.new
-        if grep -q -e "Kernel panic" -e "Oops" -e "general protection fault" \
-                -e "general protection handler: wrong gs" -e "\(XEN\) Panic" \
--               -e "fault" -e "warn" -e "BUG" ./dmesg.new ; then
-+               -e "fault" -e "warn" -e "\<BUG\>" ./dmesg.new ; then
-                tst_res TFAIL "Issues found in dmesg!"
-        else
-                tst_res TPASS "Dynamic debug OK"
+ 	sed -i -e 1,`wc -l < ./dmesg.old`d ./dmesg.new
+ 	if grep -q -e "Kernel panic" -e "Oops" -e "general protection fault" \
+ 		-e "general protection handler: wrong gs" -e "\(XEN\) Panic" \
+-		-e "fault" -e "warn" -e "BUG" ./dmesg.new ; then
++		-e "fault" -e "warn" -e "\<BUG\>" ./dmesg.new ; then
+ 		tst_res TFAIL "Issues found in dmesg!"
+ 	else
+ 		tst_res TPASS "Dynamic debug OK"

--- a/distribution/ltp-upstream/lite/patches/oom_aborts_runtest.patch
+++ b/distribution/ltp-upstream/lite/patches/oom_aborts_runtest.patch
@@ -1,0 +1,13 @@
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index a0c1b9b00..0833fd602 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -77,6 +77,8 @@ static void child_alloc(int testcase, int lite, int threads)
+ 	int i;
+ 	pthread_t *th;
+ 
++	FILE_PRINTF("/proc/self/oom_adj", "10");
++
+ 	if (lite) {
+ 		int ret = alloc_mem(TESTMEM + MB, testcase);
+ 		exit(ret);

--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -58,7 +58,7 @@ function ltp_test_build()
 		pushd ltp; git pull  > /dev/null 2>&1; popd
 	else
 		if [ $GIT_USER_ADDR = 0 ]; then
-			git clone https://github.com/linux-test-project/ltp ltp  --depth=1\
+			git clone https://github.com/linux-test-project/ltp ltp \
 				> /dev/null 2>&1 || test_msg fail "git clone ltp upstream failed"
 
 			test_msg pass "git clone LTP upstream"
@@ -81,6 +81,8 @@ function ltp_test_build()
 	patch -p1 < ../patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
 	# Debug kernels will fail dmesg check when greping for BUG
 	patch -p1 < ../patches/dynamic_debug_dmesg_check.patch
+	# OOM kills runtest.sh
+	patch -p1 < ../patches/oom_aborts_runtest.patch
 	popd > /dev/null 2>&1
 
 	test_msg pass "LTP build/install successful"


### PR DESCRIPTION
Workaround for oom test killing runtest.sh, also fixing up another patch which used space indentation vs tabs, one more change related to a git clone option which would cause the checkout to sometimes fail, please see J:3823120 for a test job.