### PR TITLE
Remove time limits from all tests

### DIFF
--- a/acpi/acpitable/Makefile
+++ b/acpi/acpitable/Makefile
@@ -43,7 +43,6 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     ACPI table Test Utility" >> $(METADATA)
-	@echo "TestTime:        15m" >> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/container/podman/Makefile
+++ b/container/podman/Makefile
@@ -43,7 +43,6 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Podman System Test" >> $(METADATA)
-	@echo "TestTime:        15m" >> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/cpu/die/Makefile
+++ b/cpu/die/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  cpu die testing" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     5m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     python2-lxml" >> $(METADATA)
 	@echo "Requires:     python3-lxml" >> $(METADATA)

--- a/cpu/driver/Makefile
+++ b/cpu/driver/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  cpu frequency driver testing" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     msr-tools" >> $(METADATA)
 	@echo "Requires:     virt-what" >> $(METADATA)

--- a/cpu/idle/Makefile
+++ b/cpu/idle/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  cpu idle power testing" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     msr-tools" >> $(METADATA)
 	@echo "Requires:     git" >> $(METADATA)

--- a/distribution/kernel-debuginfo/Makefile
+++ b/distribution/kernel-debuginfo/Makefile
@@ -44,7 +44,6 @@ $(METADATA): Makefile
 	@echo "Path:            /tmp/" >> $(METADATA)
 	@echo "Description:     Ensure that debuginfo vmlinux comes with .debug* sections." >> $(METADATA)
 	@echo "Type:            Misc" >> $(METADATA)
-	@echo "TestTime:        20m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Requires:        kmod" >> $(METADATA)

--- a/distribution/kpkginstall/Makefile
+++ b/distribution/kpkginstall/Makefile
@@ -41,7 +41,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Description:     Install kernel from a tarball" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPL" >> $(METADATA)

--- a/distribution/ltp-upstream/include/Makefile
+++ b/distribution/ltp-upstream/include/Makefile
@@ -44,7 +44,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  Linux Test Project - include">> $(METADATA)
-	@echo "TestTime:     5h" >> $(METADATA)
 	@echo "RunFor:       kernel glibc" >> $(METADATA)
 	@echo "Requires:     @development " >> $(METADATA)
 	@echo "Requires:     procmail rsyslog sysklogd ntpdate util-linux util-linux-ng redhat-lsb bc wget bzip2" >> $(METADATA)

--- a/distribution/ltp-upstream/include/metadata
+++ b/distribution/ltp-upstream/include/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=5h
 dependencies=gcc;gcc-c++;autoconf;automake;binutils;glibc-devel;procmail;rsyslog;util-linux;redhat-lsb;bc;wget;bzip2;virt-what
 softDependencies=ntpdate;chrony
 dependencies[RedHatEnterpriseLinuxServer5]=procmail;rsyslog;ntpdate;util-linux;util-linux-ng;redhat-lsb;bc;wget;sysklogd

--- a/distribution/ltp-upstream/lite/Makefile
+++ b/distribution/ltp-upstream/lite/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  test ltp patches using git version ">> $(METADATA)
-	@echo "TestTime:     48h" >> $(METADATA)
 	@echo "RunFor:       kernel glibc" >> $(METADATA)  
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)  
 	@echo "Requires:     git autoconf automake"      >> $(METADATA)

--- a/distribution/ltp/include/Makefile
+++ b/distribution/ltp/include/Makefile
@@ -45,7 +45,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  Linux Test Project - include">> $(METADATA)
-	@echo "TestTime:     5h" >> $(METADATA)
 	@echo "RunFor:       kernel glibc" >> $(METADATA)
 	@echo "Requires:     @development " >> $(METADATA)
 	@echo "Requires:     procmail rsyslog sysklogd ntpdate util-linux util-linux-ng redhat-lsb bc wget" >> $(METADATA)

--- a/distribution/ltp/include/metadata
+++ b/distribution/ltp/include/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=5h
 dependencies=procmail;rsyslog;util-linux;redhat-lsb;bc;wget
 softDependencies=ntpdate;chrony
 dependencies[RedHatEnterpriseLinuxServer5]=procmail;rsyslog;ntpdate;util-linux;util-linux-ng;redhat-lsb;bc;wget;sysklogd

--- a/distribution/ltp/lite/Makefile
+++ b/distribution/ltp/lite/Makefile
@@ -140,7 +140,6 @@ $(METADATA):
 	@echo "Name:            $(TEST)" >$(METADATA)
 	@echo "Description:     Latest LTP test KernelTier1" >>$(METADATA)
 	@echo "Path:            $(TEST_DIR)" >>$(METADATA)
-	@echo "TestTime:        180m" >>$(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >>$(METADATA)
 	@echo "License:         GPLv3" >>$(METADATA)
 	@echo "RhtsRequires:    kernel-kernel-distribution-ltp-include" >> $(METADATA)

--- a/distribution/ltp/lite/metadata
+++ b/distribution/ltp/lite/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=180m
 dependencies=automake;autoconf;procmail;flex;bison;rsyslog;util-linux;rpm-build;gcc;wget;kernel-headers;redhat-lsb;bc;kernel-devel;libaio-devel;libcap-devel;libcgroup;strace
 softDependencies=numactl;numactl-devel;redhat-lsb;ntpdate;chrony
 repoRequires=distribution/ltp/include

--- a/distribution/ltp/openposix_testsuite/Makefile
+++ b/distribution/ltp/openposix_testsuite/Makefile
@@ -79,7 +79,6 @@ $(METADATA):
 	@echo "Name:            $(TEST)" >$(METADATA)
 	@echo "Description:     Open posix testsuite (from LTP)" >>$(METADATA)
 	@echo "Path:            $(TEST_DIR)" >>$(METADATA)
-	@echo "TestTime:        90m" >>$(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >>$(METADATA)
 	@echo "License:         GPLv3" >>$(METADATA)
 	@echo "Requires:        automake autoconf procmail flex bison rsyslog sysklogd util-linux-ng rpm-build" >> $(METADATA)

--- a/distribution/ltp/openposix_testsuite/metadata
+++ b/distribution/ltp/openposix_testsuite/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=120m
 dependencies=automake;autoconf;flex;bison;rsyslog;util-linux-ng;rpm-build;kernel-headers;redhat-lsb;bc;numactl;time;kernel-devel;libaio-devel;libcap-devel;strace;gcc
 softDependencies=numactl-devel;ntpdate;chrony;sysklogd
 repoRequires=distribution/ltp/include

--- a/example/Makefile
+++ b/example/Makefile
@@ -32,6 +32,5 @@ $(METADATA):
 	@echo "License:		GPLv3" >>$(METADATA)
 	@echo "Description: 	Dummy test." >>$(METADATA)
 	@echo "Architectures:	x86_64" >>$(METADATA)
-	@echo "TestTime:	1m" >>$(METADATA)
 
 	rhts-lint $(METADATA)

--- a/filesystems/cifs/connectathon/Makefile
+++ b/filesystems/cifs/connectathon/Makefile
@@ -71,7 +71,6 @@ $(METADATA): Makefile
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  Connectathon for CIFS ">> $(METADATA)
 	@echo "Releases:     -RHEL2.1 -RHEL3" >> $(METADATA)
-	@echo "TestTime:     1h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     wget git samba time patch" >> $(METADATA)
 	@echo "Requires:     cups samba-client cifs-utils" >> $(METADATA)

--- a/filesystems/general/pjd-fstest/Makefile
+++ b/filesystems/general/pjd-fstest/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Tests POSIX features of file system" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        1h" >> $(METADATA)
 	@echo "RunFor:          filesystems" >> $(METADATA)
 	@echo "Requires:        filesystems" >> $(METADATA)
 	@echo "Requires:        library(kernel/fs)" >> $(METADATA)

--- a/filesystems/loopdev/sanity/Makefile
+++ b/filesystems/loopdev/sanity/Makefile
@@ -58,7 +58,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"	> $(METADATA)
 	@echo "Description:	Sanity test for loop device" >> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	15m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Releases:	RHEL7 Fedorarawhide" >> $(METADATA)
 	@echo "#Architectures:	All"		>> $(METADATA)

--- a/filesystems/nfs/connectathon/Makefile
+++ b/filesystems/nfs/connectathon/Makefile
@@ -80,7 +80,6 @@ $(METADATA):
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  Connectathon Testsuite\
 		 to test NFS versions 2,3 and 4." >> $(METADATA)
-	@echo "TestTime:     240m"		>> $(METADATA)
 	@echo "RunFor:       kernel"		>> $(METADATA)
 	@echo "RunFor:       nfs-utils"		>> $(METADATA)
 	@echo "Requires:     nfs-utils"		>> $(METADATA)

--- a/filesystems/xfs/xfstests/Makefile
+++ b/filesystems/xfs/xfstests/Makefile
@@ -40,7 +40,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2"             >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"    >> $(METADATA)
 	@echo "Description:  $(DESCRIPTION)"    >> $(METADATA)
-	@echo "TestTime:     24h"               >> $(METADATA)
 	@echo "RunFor:       kernel"            >> $(METADATA)
 	@echo "RunFor:       xfsprogs"          >> $(METADATA)
 	@echo "RunFor:       xfsdump"           >> $(METADATA)

--- a/iommu/boot/Makefile
+++ b/iommu/boot/Makefile
@@ -37,7 +37,6 @@ $(METADATA):
 	@echo "Description:	boot kernel with different iommu options" \
 				>>$(METADATA)
 	@echo "Path:		$(TEST_DIR)" >>$(METADATA)
-	@echo "TestTime:	1h" >>$(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>>$(METADATA)
 	@echo "Destructive:	no" >>$(METADATA)
 	@echo "Confidential:	no" >>$(METADATA)

--- a/ipmi/stress/driver/Makefile
+++ b/ipmi/stress/driver/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     IPMI driver load stress test" >> $(METADATA)
 	@echo "Type:            Stress" >> $(METADATA)
-	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        dmidecode" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/ipmi/stress/ipmitool-loop/Makefile
+++ b/ipmi/stress/ipmitool-loop/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     IPMItool loop stress test" >> $(METADATA)
 	@echo "Type:            Stress" >> $(METADATA)
-	@echo "TestTime:        120m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        ipmitool" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/jvm/Makefile
+++ b/jvm/Makefile
@@ -42,7 +42,6 @@ $(METADATA): Makefile
 	@echo "Name:            $(TEST)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     jvm tests" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/kdump/include/Makefile
+++ b/kdump/include/Makefile
@@ -42,7 +42,6 @@ $(METADATA):
 	@echo "Name:         $(TEST)"                            > $(METADATA)
 	@echo "Path:         $(TEST_DIR)"                        >>$(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"                     >>$(METADATA)
-	@echo "TestTime:     5m"                                 >>$(METADATA)
 	@echo "License:      GPLv3"                              >>$(METADATA)
 	@echo "Owner:        Kdump QE <kdump-qe-list@redhat.com>"      >>$(METADATA)
 	@echo "Description:  kdump test library" >>$(METADATA)

--- a/kdump/kdump-sysrq-c/Makefile
+++ b/kdump/kdump-sysrq-c/Makefile
@@ -42,7 +42,6 @@ $(METADATA):
 	@echo "Name:         $(TEST)"                            > $(METADATA)
 	@echo "Path:         $(TEST_DIR)"                        >>$(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"                     >>$(METADATA)
-	@echo "TestTime:     30m"                                >>$(METADATA)
 	@echo "License:      GPLv3"                              >>$(METADATA)
 	@echo "Owner:        Kdump QE <kdump-qe-list@redhat.com>"      >>$(METADATA)
 	@echo "repoRequires: kdump/include"      >> $(METADATA)

--- a/legacy/pci_id/Makefile
+++ b/legacy/pci_id/Makefile
@@ -45,7 +45,6 @@ $(METADATA): Makefile
 	@echo "Path:            /tmp/" >> $(METADATA)
 	@echo "Description:     Ensure no pci id gets removed." >> $(METADATA)
 	@echo "Type:            Misc" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Requires:        kmod" >> $(METADATA)

--- a/legacy/shared/Makefile
+++ b/legacy/shared/Makefile
@@ -44,7 +44,6 @@ $(METADATA):
 	@echo "TestVersion:	$(TESTVERSION)"	>>$(METADATA)
 	@echo "License:		GPLv3" >>$(METADATA)
 	@echo "Description: 	Make sure legacy env is setup." >>$(METADATA)
-	@echo "TestTime:	5m" >>$(METADATA)
 
 	rhts-lint $(METADATA)
 

--- a/legacy/whitelist/Makefile
+++ b/legacy/whitelist/Makefile
@@ -45,7 +45,6 @@ $(METADATA): Makefile
 	@echo "Path:            /tmp/" >> $(METADATA)
 	@echo "Description:     Ensure no symbol is removed from kABI whitelist." >> $(METADATA)
 	@echo "Type:            Misc" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Requires:        kmod" >> $(METADATA)

--- a/memory/function/kaslr/Makefile
+++ b/memory/function/kaslr/Makefile
@@ -67,7 +67,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     This is a general regression test for VM" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        1h" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/memory/function/kaslr/metadata
+++ b/memory/function/kaslr/metadata
@@ -8,6 +8,5 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=120m
 dependencies=
 repoRequires=

--- a/memory/function/memfd_create/Makefile
+++ b/memory/function/memfd_create/Makefile
@@ -62,7 +62,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test for memfd_create syscall." >> $(METADATA)
 	@echo "Type:            Function" >> $(METADATA)
-	@echo "TestTime:        20m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        @development" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/misc/amtu/Makefile
+++ b/misc/amtu/Makefile
@@ -43,7 +43,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"	> $(METADATA)
 	@echo "Description:	Abstract Machine Test Utility" >> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	10m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Releases:	-RHEL2.1 -RHEL3" >> $(METADATA)
 	@echo "Destructive:	no"		>> $(METADATA)

--- a/misc/header-test/Makefile
+++ b/misc/header-test/Makefile
@@ -42,7 +42,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"				>> $(METADATA)
 	@echo "Description:	Sanity test for kernel-headers" 	>> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"				>> $(METADATA)
-	@echo "TestTime:	10m"					>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"				>> $(METADATA)
 	@echo "Releases:	RHEL6 RHEL7 RHEL8 RedHatEnterpriseLinux6 RedHatEnterpriseLinux7 RedHatEnterpriseLinux8" >> $(METADATA)
 	@echo "Architectures:	i386 x86_64 ppc64 ppc64le s390x aarch64"	>> $(METADATA)

--- a/misc/header-test/metadata
+++ b/misc/header-test/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=10m
 dependencies[RedHatEnterpriseLinux6]=kernel-headers;gcc;bash;python
 dependencies[RedHatEnterpriseLinux7]=kernel-headers;gcc;bash;python
 dependencies[RedHatEnterpriseLinux8]=kernel-headers;gcc;bash;platform-python;python2

--- a/misc/kernel-fips-mode/Makefile
+++ b/misc/kernel-fips-mode/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test kernel FIPS 140 mode" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/misc/module-load/Makefile
+++ b/misc/module-load/Makefile
@@ -49,7 +49,6 @@ $(METADATA): Makefile
 	@echo "Description:  Simple kernel sanity\
 		check that loads and unloads various\
 		kernel modules"			>> $(METADATA)
-	@echo "TestTime:     60m"		>> $(METADATA)
 	@echo "Releases:     -RHEL2.1"		>> $(METADATA)
 	@echo "#Architectures: All"		>> $(METADATA)
 	@echo "Destructive:  no"		>> $(METADATA)

--- a/networking/bridge/sanity_check/Makefile
+++ b/networking/bridge/sanity_check/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  bridge sanity test" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     1h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "RepoRequires: networking/common" >> $(METADATA)

--- a/networking/common/Makefile
+++ b/networking/common/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  common routines for networking tests">> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here
 	@echo "RhtsRequires: beakerlib-redhat" >> $(METADATA)

--- a/networking/common/metadata
+++ b/networking/common/metadata
@@ -8,6 +8,5 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=180m
 dependencies=net-tools;iproute;tcpdump;nmap;ethtool;nc;nmap-ncat;socat;libtool;bind-utils;libteam;teamd;traceroute;expect;bc;wget;bzip2;gcc;git;patch;rsync
 softDependencies=python3-pexpect;pexpect;bridge-utils

--- a/networking/driver/sanity/Makefile
+++ b/networking/driver/sanity/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Networking Driver Sanity Test" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Requires:        ethtool" >> $(METADATA)

--- a/networking/firewall/000infralib/Makefile
+++ b/networking/firewall/000infralib/Makefile
@@ -73,7 +73,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)" >> $(METADATA)
 	@echo "Description:  firewall/000infralib" >> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/firewall/netfilter/target/Makefile
+++ b/networking/firewall/netfilter/target/Makefile
@@ -77,7 +77,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  Basic netfilter tests" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     24h" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     nmap-ncat socat lksctp-tools" >> $(METADATA)
 	@echo "Requires:     tree" >> $(METADATA)

--- a/networking/igmp/conformance/Makefile
+++ b/networking/igmp/conformance/Makefile
@@ -54,7 +54,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test setting and getting of socket options for multicast and IGMP." >> $(METADATA)
 	@echo "Type:            Function" >> $(METADATA)
-	@echo "TestTime:        1h" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        kernel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/Makefile
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/Makefile
@@ -71,7 +71,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  ipsec/ipsec_basic/ipsec_basic_netns">> $(METADATA)
-	@echo "TestTime:     40m" >> $(METADATA)
 	@echo "Type:         Function" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here

--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/metadata
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/metadata
@@ -8,6 +8,5 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=60m
 dependencies=socat;iproute
 repoRequires=networking/common

--- a/networking/macsec/sanity_check/Makefile
+++ b/networking/macsec/sanity_check/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  MACsec sanity test" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     2h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "RepoRequires: networking/common" >> $(METADATA)

--- a/networking/route/pmtu/Makefile
+++ b/networking/route/pmtu/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  pmtu tests">> $(METADATA)
-	@echo "TestTime:     1h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/route/route_func/Makefile
+++ b/networking/route/route_func/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  route and rule functions">> $(METADATA)
-	@echo "TestTime:     3h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/route/route_func/metadata
+++ b/networking/route/route_func/metadata
@@ -8,6 +8,5 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=180m
 dependencies=net-tools
 repoRequires=networking/common

--- a/networking/sctp/auth/sockopts/Makefile
+++ b/networking/sctp/auth/sockopts/Makefile
@@ -49,7 +49,6 @@ $(METADATA): Makefile
 	@echo "Description:     sctp auth socket ops test" >> $(METADATA)
 	@echo "Type:            functional" >> $(METADATA)
 	@echo "Type:            Singlehost" >> $(METADATA)
-	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/networking/socket/fuzz/Makefile
+++ b/networking/socket/fuzz/Makefile
@@ -77,7 +77,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  A socket testing framework for all protocols">> $(METADATA)
-	@echo "TestTime:     3h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/socket/fuzz/metadata
+++ b/networking/socket/fuzz/metadata
@@ -8,5 +8,4 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=180m
 repoRequires=networking/common

--- a/networking/tcp/tcp_keepalive/Makefile
+++ b/networking/tcp/tcp_keepalive/Makefile
@@ -71,7 +71,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv2" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  tcp/tcp_keepalive">> $(METADATA)
-	@echo "TestTime:     20m" >> $(METADATA)
 	@echo "Type:         Function" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here

--- a/networking/tunnel/common/Makefile
+++ b/networking/tunnel/common/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  tunnel common">> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/tunnel/common/metadata
+++ b/networking/tunnel/common/metadata
@@ -8,6 +8,5 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=60m
 dependencies=net-tools;iproute;tcpdump;ethtool
 repoRequires=networking/common

--- a/networking/tunnel/geneve/basic/Makefile
+++ b/networking/tunnel/geneve/basic/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  geneve basic">> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/tunnel/geneve/basic/metadata
+++ b/networking/tunnel/geneve/basic/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=60m
 dependencies=beakerlib;beakerlib-redhat;net-tools;tcpdump;wget;bzip2;gcc;git;patch
 softDependencies=python3-lxml;kernel-modules-extra
 repoRequires=networking/common;networking/tunnel/common;cki_lib

--- a/networking/tunnel/gre/basic/Makefile
+++ b/networking/tunnel/gre/basic/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  tunnel basic">> $(METADATA)
-	@echo "TestTime:     60m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/tunnel/gre/basic/metadata
+++ b/networking/tunnel/gre/basic/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=60m
 dependencies=beakerlib;beakerlib-redhat;net-tools;tcpdump;wget;bzip2;gcc;git;patch;socat
 softDependencies=python3-lxml;kernel-modules-extra
 repoRequires=networking/common;networking/tunnel/common;cki_lib

--- a/networking/tunnel/l2tp/basic/Makefile
+++ b/networking/tunnel/l2tp/basic/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  l2tp basic">> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/tunnel/vxlan/basic/Makefile
+++ b/networking/tunnel/vxlan/basic/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "License:      GPL" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
 	@echo "Description:  vxlan basic">> $(METADATA)
-	@echo "TestTime:     30m" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA) 
 # add any other packages for which your test ought to run here
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)

--- a/networking/tunnel/vxlan/basic/metadata
+++ b/networking/tunnel/vxlan/basic/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=30m
 dependencies=beakerlib;beakerlib-redhat;net-tools;tcpdump;wget;bzip2;gcc;git;patch
 softDependencies=python3-lxml;kernel-modules-extra
 repoRequires=networking/common;networking/tunnel/common;cki_lib

--- a/networking/udp/udp_socket/Makefile
+++ b/networking/udp/udp_socket/Makefile
@@ -77,7 +77,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  udp socket testing" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     5m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     make" >> $(METADATA)
 	@echo "Requires:     gcc" >> $(METADATA)

--- a/networking/vnic/ipvlan/basic/Makefile
+++ b/networking/vnic/ipvlan/basic/Makefile
@@ -54,7 +54,6 @@ $(METADATA): Makefile
 	@echo "Description:  ipvlan basic">> $(METADATA)
 	@echo "License:      GPLv2 or above" >> $(METADATA)
 	@echo "Type:         Functional" >> $(METADATA)
-	@echo "TestTime:     3h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     net-tools" >> $(METADATA)

--- a/packages/audit/audit-testsuite/Makefile
+++ b/packages/audit/audit-testsuite/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Execute audit-testsuite" >> $(METADATA)
 	@echo "Type:            Sanity Regression" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          audit" >> $(METADATA)
 	@echo "Requires:        kernel git audit perl perl-Test perl-Test-Harness perl-File-Which perl-Time-HiRes gcc libgcc glibc-devel glibc-devel.i686 libgcc.i686 glibc-devel.s390 libgcc.s390 glibc-devel.ppc libgcc.ppc expect nmap-ncat" >> $(METADATA)
 	@echo "Requires:        gcc autoconf automake binutils gettext libtool make patch pkgconfig bison flex" >> $(METADATA)

--- a/packages/httpd/mod_ssl-smoke/Makefile
+++ b/packages/httpd/mod_ssl-smoke/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     try to reinstall mod_ssl and run httpd with mod_ssl" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          httpd" >> $(METADATA)
 	@echo "Requires:        httpd mod_ssl python" >> $(METADATA)
 	@echo "Requires:        python2 python3" >> $(METADATA)

--- a/packages/httpd/php-mysql-sanity/Makefile
+++ b/packages/httpd/php-mysql-sanity/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     test fetching data from mysqldb/mariadb through php" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          httpd" >> $(METADATA)
 	@echo "Requires:        httpd php php-zts php-mysqlnd mariadb-server" >> $(METADATA)
 	@echo "RhtsRequires:    library(httpd/http)" >> $(METADATA)

--- a/packages/i2c-tools/sanity/i2cdetect-smoke/Makefile
+++ b/packages/i2c-tools/sanity/i2cdetect-smoke/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Loads i2c-dev module, tries i2cdetect -l. If something is detected probes for more info." >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          i2c-tools" >> $(METADATA)
 	@echo "Requires:        i2c-tools" >> $(METADATA)
 	@echo "Requires:        python3-lxml" >> $(METADATA)

--- a/packages/iotop/sanity/Makefile
+++ b/packages/iotop/sanity/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     verifies that iotop can detect heavy disk load simulated by dd" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          iotop" >> $(METADATA)
 	@echo "Requires:        iotop" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/packages/perf/internal-testsuite/Makefile
+++ b/packages/perf/internal-testsuite/Makefile
@@ -51,7 +51,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     internal-testsuite" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          perf" >> $(METADATA)
 	@echo "Requires:        perf perf-debuginfo" >> $(METADATA)
 	@echo "Requires:        python-perf python3-perf" >> $(METADATA)

--- a/packages/perf/perftool-testsuite/Makefile
+++ b/packages/perf/perftool-testsuite/Makefile
@@ -51,7 +51,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     the test runs upstream perftool-testsuite in CKI" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          perf" >> $(METADATA)
 	@echo "Requires:        perf virt-what elfutils kernel-debuginfo kernel-debug-debuginfo git bc gcc-c++" >> $(METADATA)
 	@echo "Requires:        coreutils-debuginfo yum-utils dnf-utils" >> $(METADATA)

--- a/packages/redhat-rpm-config/detect-kabi-provides/Makefile
+++ b/packages/redhat-rpm-config/detect-kabi-provides/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test for BZ#1004930 (kernel-tools-3.10.0-11.el7.x86_64 requires)" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          redhat-rpm-config" >> $(METADATA)
 	@echo "Requires:        redhat-rpm-config rpm-build kernel-devel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/packages/redhat-rpm-config/kabi-whitelist-not-found/Makefile
+++ b/packages/redhat-rpm-config/kabi-whitelist-not-found/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test for BZ#1126086 (KERNEL ABI COMPATIBILITY WARNING when building any)" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          redhat-rpm-config" >> $(METADATA)
 	@echo "Requires:        redhat-rpm-config kernel-abi-whitelists kernel-rpm-macros" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/packages/redhat-rpm-config/kernel-module-symbol-requires/Makefile
+++ b/packages/redhat-rpm-config/kernel-module-symbol-requires/Makefile
@@ -51,7 +51,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test for BZ#1619235 (Incorrect kernel module symbol Requires generation)" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          redhat-rpm-config" >> $(METADATA)
 	@echo "Requires:        redhat-rpm-config kernel-rpm-macros rpm-build kernel-devel kernel-abi-whitelists gcc kernel-devel elfutils-libelf-devel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/packages/selinux-policy/serge-testsuite/Makefile
+++ b/packages/selinux-policy/serge-testsuite/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     functional test suite for the LSM-based SELinux security module" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "RunFor:          selinux-policy" >> $(METADATA)
 	@echo "Requires:        attr" >> $(METADATA)
 	@echo "Requires:        audit" >> $(METADATA)

--- a/packages/tuned/basic/Makefile
+++ b/packages/tuned/basic/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Library for tuned" >> $(METADATA)
 	@echo "Type:            Library" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          tuned" >> $(METADATA)
 	@echo "Requires:        tuned" >> $(METADATA)
 	@echo "Provides:        library(tuned/basic)" >> $(METADATA)

--- a/packages/tuned/basic/metadata
+++ b/packages/tuned/basic/metadata
@@ -8,5 +8,4 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=10m
 dependencies=beakerlib;beakerlib-redhat;tuned

--- a/packages/tuned/tune-processes-through-perf/Makefile
+++ b/packages/tuned/tune-processes-through-perf/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test if we can tune new process via perf" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          tuned" >> $(METADATA)
 	@echo "Requires:        tuned" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/packages/tuned/tune-processes-through-perf/metadata
+++ b/packages/tuned/tune-processes-through-perf/metadata
@@ -8,7 +8,6 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=20m
 dependencies=beakerlib;beakerlib-redhat;tuned
 softDependencies=python3-lxml
 repoRequires=packages/tuned/basic

--- a/pciutils/sanity-smoke/Makefile
+++ b/pciutils/sanity-smoke/Makefile
@@ -51,7 +51,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     test whether lspci works" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        15m" >> $(METADATA)
 	@echo "RunFor:          pciutils" >> $(METADATA)
 	@echo "Requires:        pciutils" >> $(METADATA)
 	@echo "Requires:        python2-lxml" >> $(METADATA)

--- a/pciutils/update-pciids/Makefile
+++ b/pciutils/update-pciids/Makefile
@@ -49,7 +49,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Checks if update-pciids runs successfully" >> $(METADATA)
 	@echo "Type:            Sanity" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          pciutils" >> $(METADATA)
 	@echo "Requires:        pciutils" >> $(METADATA)
 	@echo "Requires:        python2-lxml" >> $(METADATA)

--- a/power-management/cpupower/sanity/Makefile
+++ b/power-management/cpupower/sanity/Makefile
@@ -50,7 +50,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  Check, that output of cpupower is sane" >> $(METADATA)
 	@echo "Type:         Sanity" >> $(METADATA)
-	@echo "TestTime:     5m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     kernel" >> $(METADATA)
 	@echo "Requires:     kernel-tools" >> $(METADATA)

--- a/power-management/rapl/powercap/Makefile
+++ b/power-management/rapl/powercap/Makefile
@@ -49,7 +49,6 @@ $(METADATA): Makefile
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  Confirm RAPL is supported" >> $(METADATA)
 	@echo "Type:         Sanity" >> $(METADATA)
-	@echo "TestTime:     5m" >> $(METADATA)
 	@echo "RunFor:       kernel" >> $(METADATA)
 	@echo "Requires:     kernel" >> $(METADATA)
 	@echo "Requires:     virt-what" >> $(METADATA)

--- a/power-management/suspend-resume/Makefile
+++ b/power-management/suspend-resume/Makefile
@@ -58,7 +58,6 @@ $(METADATA): Makefile
 	@echo "Name:		$(TEST)"	> $(METADATA)
 	@echo "Description:	"Checking the boottime after the system suspend >> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	240m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Destructive:	no"		>> $(METADATA)
 	@echo "Confidential:	no"		>> $(METADATA)

--- a/rt-tests/include/Makefile
+++ b/rt-tests/include/Makefile
@@ -45,6 +45,5 @@ $(METADATA):
 	@echo "License:		GPLv3" >>$(METADATA)
 	@echo "Description: 	Make sure rt env setup." >>$(METADATA)
 	@echo "Architectures:	x86_64" >>$(METADATA)
-	@echo "TestTime:	10m" >>$(METADATA)
 
 	rhts-lint $(METADATA)

--- a/rt-tests/rt_migrate_test/Makefile
+++ b/rt-tests/rt_migrate_test/Makefile
@@ -46,7 +46,6 @@ $(METADATA): Makefile
 	@echo "Description:	Test to verify CPUs should be running the highest\
 			        possible priority task that it can run." >> $(METADATA)
 	@echo "Architectures:   x86_64" >>$(METADATA)
-	@echo "TestTime:	1h"	>> $(METADATA)
 	@echo "repoRequires:	rt-tests/include" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/rt-tests/rteval/Makefile
+++ b/rt-tests/rteval/Makefile
@@ -45,7 +45,6 @@ $(METADATA): Makefile
 	@echo "License:		GPLv2" >> $(METADATA)
 	@echo "Description:	PRE Verification for Real Time" >> $(METADATA)
 	@echo "Architectures:	x86_64" >>$(METADATA)
-	@echo "TestTime:	1h" >> $(METADATA)
 	@echo "repoRequires:	rt-tests/include" >> $(METADATA)  
 
 	rhts-lint $(METADATA)

--- a/rt-tests/sched_deadline/Makefile
+++ b/rt-tests/sched_deadline/Makefile
@@ -45,7 +45,6 @@ $(METADATA):
 	@echo "License:		GPLv3" >>$(METADATA)
 	@echo "Description:	Special deadline_test on rt kernel." >>$(METADATA)
 	@echo "Architectures:	x86_64" >>$(METADATA)
-	@echo "TestTime:	10m" >>$(METADATA)
 	@echo "repoRequires:	rt-tests/include" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/rt-tests/smidetect/Makefile
+++ b/rt-tests/smidetect/Makefile
@@ -46,7 +46,6 @@ $(METADATA): Makefile
 	@echo "License:		GPLv2"		>> $(METADATA)
 	@echo "Description:	Test to detect System Management Interrupts (SMIs)" >> $(METADATA)
 	@echo "Architectures:	x86_64" >> $(METADATA)
-	@echo "TestTime:	1h"	>> $(METADATA)
 	@echo "repoRequires:	rt-tests/include"  >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/sound/aloop/Makefile
+++ b/sound/aloop/Makefile
@@ -40,7 +40,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     ALSA PCM loopback test (snd-aloop)" >> $(METADATA)
 	@echo "Type:            Functional" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/sound/user-ctl-elem/Makefile
+++ b/sound/user-ctl-elem/Makefile
@@ -40,7 +40,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     ALSA Control (mixer) Userspace Element test" >> $(METADATA)
 	@echo "Type:            Functional" >> $(METADATA)
-	@echo "TestTime:        2m" >> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/standards/usex/1.9-29/Makefile
+++ b/standards/usex/1.9-29/Makefile
@@ -220,7 +220,6 @@ $(METADATA): Makefile
 	@echo "Name:		$(TEST)"	>> $(METADATA)
 	@echo "Description:	Dave Anderson's Usex test 1.9-29"	>> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	30m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Releases:	-RHEL3"		>> $(METADATA)
 	@echo "#Architectures:	All"		>> $(METADATA)

--- a/storage/blk/Makefile
+++ b/storage/blk/Makefile
@@ -66,7 +66,6 @@ $(METADATA):
 	@echo "License:      GPLv2 or above"    >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"    >> $(METADATA)
 	@echo "Description:  blktests"          >> $(METADATA)
-	@echo "TestTime:     10m"               >> $(METADATA)
 	@echo "Requires:     fio"		>> $(METADATA)
 	@echo "Requires:     blktrace"		>> $(METADATA)
 	@echo "Requires:     gcc"		>> $(METADATA)

--- a/storage/dm/common/Makefile
+++ b/storage/dm/common/Makefile
@@ -35,7 +35,6 @@ $(METADATA): Makefile
 	@echo "TestVersion:  $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:         $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:  Tests device-mapper, mainly Core">> $(METADATA)
-	@echo "TestTime:     1h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:     git" >> $(METADATA)

--- a/storage/hba/san-device-stress/Makefile
+++ b/storage/hba/san-device-stress/Makefile
@@ -54,7 +54,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     This test will generate I/O using FIO at the device level." >> $(METADATA)
 	@echo "License:		GPL v3" >> $(METADATA)
-	@echo "TestTime:	1h" >> $(METADATA)
 	@echo "RunFor:		$(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:        python2-lxml" >> $(METADATA)
 	@echo "Requires:        python3-lxml" >> $(METADATA)

--- a/storage/iscsi/params/Makefile
+++ b/storage/iscsi/params/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     iSCSI parameters testing" >> $(METADATA)
 	@echo "Type:            Functional" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        git" >> $(METADATA)
 	@echo "Requires:        wget" >> $(METADATA)

--- a/storage/lvm/thinp/sanity/Makefile
+++ b/storage/lvm/thinp/sanity/Makefile
@@ -53,7 +53,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"	> $(METADATA)
 	@echo "Description:	Sanity test for lvm thinp" >> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	60m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Releases:	RedHatEnterpriseLinux7 RedHatEnterpriseLinuxPegas7 RedHatEnterpriseLinuxAlternateArchitectures7 Fedora25 Fedora26 Fedorarawhide" >> $(METADATA)
 	@echo "#Architectures:	All"		>> $(METADATA)

--- a/storage/scsi/vpd/Makefile
+++ b/storage/scsi/vpd/Makefile
@@ -55,7 +55,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     check the scsi device vpd" >> $(METADATA)
 	@echo "Type:            Regression" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          $(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:        device-mapper-multipath sg3_utils" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)

--- a/storage/swraid/trim/Makefile
+++ b/storage/swraid/trim/Makefile
@@ -69,7 +69,6 @@ $(METADATA): Makefile
 	@echo "License:      GPLv3" >> $(METADATA)
 	@echo "TestVersion:  $(TESTVERSION)"    >> $(METADATA)
 	@echo "Description:  test the function trim support">> $(METADATA)
-	@echo "TestTime:     2h" >> $(METADATA)
 	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
 # add any other packages for which your test ought to run here
 	@echo "Requires:	 mdadm" >> $(METADATA)

--- a/stress/stress-ng/Makefile
+++ b/stress/stress-ng/Makefile
@@ -46,7 +46,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"				>> $(METADATA)
 	@echo "Description:	Run stress-ng tests"			>> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"				>> $(METADATA)
-	@echo "TestTime:	160m"					>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"				>> $(METADATA)
 	@echo "Releases:	RHEL7"					>> $(METADATA)
 	@echo "Architectures:	aarch64 ppc64le s390x x86_64"		>> $(METADATA)

--- a/test/misc/machineinfo/Makefile
+++ b/test/misc/machineinfo/Makefile
@@ -41,7 +41,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Description:     Upload machine info" >> $(METADATA)
-	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          $(TOPLEVEL_NAMESPACE)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPL" >> $(METADATA)

--- a/trace/bpf/test_bpf/Makefile
+++ b/trace/bpf/test_bpf/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test eBPF tracing using the test_bpf module" >> $(METADATA)
-	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/trace/bpf/test_bpf/metadata
+++ b/trace/bpf/test_bpf/metadata
@@ -8,5 +8,4 @@ destructive=no
 
 [restraint]
 entry_point=make run
-max_time=180m
 repoRequires=trace/include

--- a/trace/ftrace/tracer/Makefile
+++ b/trace/ftrace/tracer/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Enable ftrace tracers to see if it works" >> $(METADATA)
-	@echo "TestTime:        60m" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/trace/ftrace/tracer/metadata
+++ b/trace/ftrace/tracer/metadata
@@ -6,5 +6,4 @@ description="Minimal test for ftrace tracers"
 [restraint]
 entry_point=make run
 repoRequires=trace/include
-max_time=60m
 use_pty=true

--- a/tracepoints/operational/Makefile
+++ b/tracepoints/operational/Makefile
@@ -40,7 +40,6 @@ $(METADATA):
 	@echo "Name:		$(TEST)"	> $(METADATA)
 	@echo "Description:	Ensure tracepoints are working" >> $(METADATA)
 	@echo "Path:		$(TEST_DIR)"	>> $(METADATA)
-	@echo "TestTime:	150m"		>> $(METADATA)
 	@echo "TestVersion:	$(TESTVERSION)"	>> $(METADATA)
 	@echo "Releases:        RHELServer5 RHEL6 Fedora16 RHEL7 RedHatEnterpriseLinux7 RedHatEnterpriseLinuxPegas7 RedHatEnterpriseLinuxAlternateArchitectures7 RedHatEnterpriseLinux8" >> $(METADATA)
 	@echo "#Architectures:	All"		>> $(METADATA)

--- a/vm/hugepage/libhugetlbfs/Makefile
+++ b/vm/hugepage/libhugetlbfs/Makefile
@@ -115,7 +115,6 @@ $(METADATA): Makefile
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Test libhugetlbfs with upstream testsuite" >> $(METADATA)
-	@echo "TestTime:        40m" >> $(METADATA)
 	@echo "RunFor:          $(PACKAGE_NAME) $(PACKAGE_NAME)-utils" >> $(METADATA)
 	@echo "Requires:        @development \
 		libgcc.i686    glibc-devel.i686    glibc-static.i686 \

--- a/vm/kvm-self-tests/Makefile
+++ b/vm/kvm-self-tests/Makefile
@@ -48,7 +48,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     kvm self testing" >> $(METADATA)
 	@echo "Type:            Functional" >> $(METADATA)
-	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        make" >> $(METADATA)
 	@echo "Requires:        gcc" >> $(METADATA)

--- a/vm/kvm-unit-tests/Makefile
+++ b/vm/kvm-unit-tests/Makefile
@@ -52,7 +52,6 @@ $(METADATA): Makefile
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     kvm unit testing" >> $(METADATA)
 	@echo "Type:            Stress" >> $(METADATA)
-	@echo "TestTime:        30m" >> $(METADATA)
 	@echo "RunFor:          kernel" >> $(METADATA)
 	@echo "Requires:        qemu-kvm" >> $(METADATA)
 	@echo "Requires:        git" >> $(METADATA)


### PR DESCRIPTION
Remove "TestTime" from the old metadata files (testinfo.desc) created
by the Makefiles, and also remove "max_time" from new metadata files.

Ref. FASTMOVING-1201