### PR TITLE
Add back cve tests for LTP

### DIFF
--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -22,7 +22,7 @@
 
 TARGET_DIR=/mnt/testarea/ltp
 GIT_USER_ADDR=${GIT_USER_ADDR:-0}
-RUNTESTS=${RUNTESTS:-"sched syscalls can commands containers dio fs fsx math hugetlb mm nptl pty ipc tracing"}
+RUNTESTS=${RUNTESTS:-"cve sched syscalls can commands containers dio fs fsx math hugetlb mm nptl pty ipc tracing"}
 CPUS_NUM=$(getconf _NPROCESSORS_ONLN || echo 1)
 
 function test_msg()


### PR DESCRIPTION
This PR is to re-enable cve tests in LTP, see beaker job 3829635 for results.