### PR TITLE
networking/igmp: extend the ifindex to a very large number

### DIFF
--- a/networking/igmp/conformance/test_tools/offline/sockopt_if.c
+++ b/networking/igmp/conformance/test_tools/offline/sockopt_if.c
@@ -79,7 +79,7 @@ void test_if_v6()
 	test_setsockopt_error("IPV6_MULTICAST_IF bad optlen",
 			IPV6_MULTICAST_IF, &addr6, 3, EINVAL, 6);
 
-	addr6 = 50;
+	addr6 = 9999;
 	test_setsockopt_error("IPV6_MULTICAST_IF index 50",
 			IPV6_MULTICAST_IF, &addr6, size, ENODEV, 6);
 


### PR DESCRIPTION
This test tries to input a false ifindex and see if kernel replies a
ENODEV error. But sometimes index 50 may exist and the test would fail.
So let extend the index number to a very large and should not exist number.

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>