### PR TITLE
add tests for HW RAID for smartpqi and hpsa testing

### DIFF
--- a/storage/hw_raid/Makefile
+++ b/storage/hw_raid/Makefile
@@ -1,0 +1,68 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /kernel/storage/Sanity/dt_stress_panic
+#   Description: This test verifies that kdump is active, installs dt if necessary, then generates I/O with dt. While generating I/O, it triggers a panic. It will then verify that the server reboots properly and that a crash dump was generated.
+#   Author: Marco Patalano <mpatalan@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The toplevel namespace within which the test lives.
+TOPLEVEL_NAMESPACE=tests-beaker
+
+# # The name of the package under test:
+PACKAGE_NAME=storage
+#
+# # The path of the test below the package:
+RELATIVE_PATH=hw_raid
+#
+# # Version of the Test. Used with make tag.
+export TESTVERSION=0.1
+#
+# # The combined namespace of the test.
+export TEST=/$(TOPLEVEL_NAMESPACE)/$(PACKAGE_NAME)/$(RELATIVE_PATH)
+
+BUILT_FILES=
+
+FILES=$(METADATA) runtest.sh main.sh Makefile PURPOSE
+
+.PHONY: all install download clean
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	chmod a+x ./runtest.sh
+	chmod a+x ./main.sh
+clean:
+	rm -f *~ *.rpm $(BUILT_FILES)
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Marco Patalano <mpatalan@redhat.com>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Description:     This test will generate I/O using FIO at the device level and trigger a panic as well as kexec boot." >> $(METADATA)
+	@echo "License:		GPL v3" >> $(METADATA)
+	@echo "RunFor:		$(PACKAGE_NAME)" >> $(METADATA)
+	@echo "Requires:	$(PACKAGE_NAME)" >> $(METADATA)
+	@echo "RepoRequires:    cki_lib" >> $(METADATA)
+	@echo "RhtsRequires:	hw_raid" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/storage/hw_raid/PURPOSE
+++ b/storage/hw_raid/PURPOSE
@@ -1,0 +1,4 @@
+PURPOSE of /tests-beaker/storage/hw_raid
+Description: This test generates I/O with FIO at the device level and then trigger a panic. Additionally performs kexec boot while generating I/O
+Author: Marco Patalano <mpatalan@redhat.com>
+

--- a/storage/hw_raid/main.sh
+++ b/storage/hw_raid/main.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /kernel/storage/dt_stress/dt_stress_panic
+#   Description: This test verifies that kdump is active, installs FIO if necessary, then generates I/O with dt. While generating I/O, it triggers a panic. It will then verify that the server reboots properly and that a crash dump was generated.
+#   Author: Marco Patalano <mpatalan@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2017 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+dbg_flag=${dbg_flag:-"set +x"}
+$dbg_flag
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || exit 1
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+. ../../cki_lib/libcki.sh || exit 1
+
+
+YUM=$(cki_get_yum_tool)
+
+DATE=$(date +"%Y-%m-%d")
+crashDir=(/var/crash/127.0.0.1-$DATE-*)
+
+#function to install or start kdump:
+kdump_prepare()
+{
+    rlRun "$YUM -y install kexec-tools"
+    k_dump=$(systemctl status kdump.service |grep Active: |awk '{print $2}')
+    if [ $k_dump == "active" ]; then
+        rlLog "kdump is $k_dump"
+    else
+        rlLog "kdump is $k_dump - starting kdump service"
+        rlRun "systemctl start kdump.service"
+    fi
+}
+
+#Function to install FIO
+function install_fio() {
+
+    rlRun "which fio"
+    if [ $? -eq 0 ]; then
+        rlLog "INFO: fio already installed"
+        return
+    fi
+    rlRun "$YUM -y install fio"
+    if [ $? -eq 0 ]; then
+        rlLog "INFO: fio succesfully installed by yum -y install fio"
+        return
+    fi
+
+    git_url=git://git.kernel.org/pub/scm/linux/kernel/git/axboe/fio.git
+    rlRun "$YUM install libaio-devel zlib-devel gcc -y"
+    rlRun "git clone $git_url"
+    rlLog "INFO: Installing Fio"
+    rlRun "cd fio && ./configure && make && make install"
+    rlRun "which fio"
+    if [ $? -ne 0 ]; then
+        rlLog "FAIL: Fio install failed"
+        return 1
+    fi
+    rlLog "INFO: Fio succesfully installed"
+}
+
+#Function to generate I/O with FIO
+function FIO_Test() {
+    EX_USAGE=64 # Bad arg format
+    if [ $# -lt 1 ]; then
+        echo 'Usage: FIO_Test $test_file'
+        exit "${EX_USAGE}"
+    fi
+    # variable definitions
+    local runtime=180
+    local numjobs=60
+    local test_file="/home/test1G.img"
+
+    rlLog "INFO: Executing FIO_Test() with on: $test_file"
+
+    #fio testing
+    rlRun "fio -filename=$test_file -iodepth=1 -thread -rw=write -ioengine=psync -bssplit=5k/10:9k/10:13k/10:17k/10:21k/10:25k/10:29k/10:33k/10:37k/10:41k/10 -direct=1 -runtime=$runtime -time_based -size=1G -group_reporting -name=mytest -numjobs=$numjobs &"
+    if [ $? -ne 0 ]; then
+        rlLog "FAIL: fio write testing for $test_file failed"
+        ret=1
+    fi
+    return $ret
+}
+
+#Function to set next boot if EFI system
+PrepareReboot()
+{
+    # IA-64 needs nextboot set.
+    if [ -e "/usr/sbin/efibootmgr" ]; then
+        EFI=$(efibootmgr -v | grep BootCurrent | awk '{ print $2}')
+        if [ -n "$EFI" ]; then
+            rlLog "- Updating efibootmgr next boot option to $EFI according to BootCurrent"
+            efibootmgr -n $(efibootmgr -v | grep BootCurrent | awk '{ print $2}')
+        elif [[ -z "$EFI" && -f /root/EFI_BOOT_ENTRY.TXT ]] ; then
+            os_boot_entry=$(</root/EFI_BOOT_ENTRY.TXT)
+            rlLog "- Updating efibootmgr next boot option to $os_boot_entry according to EFI_BOOT_ENTRY.TXT"
+            efibootmgr -n $os_boot_entry
+        else
+            Log "- Could not determine value for BootNext!"
+        fi
+    fi
+}
+
+#function to trigger panic
+trigger_panic()
+{
+    #First, enable sysrq:
+    rlRun -l 'echo "1" > /proc/sys/kernel/sysrq'
+    #trigger panic:
+    report_result PANIC PASS 0
+    rlRun -l "echo c > /proc/sysrq-trigger"
+}
+
+#function to load kernel, gracefully shutdown and restart to loaded kernel
+kexec_boot_graceful()
+{
+    rlRun "unr=$(uname -r)"
+    rlRun "initrd=/boot/initramfs-$unr.img"
+    rlRun "kexec -l /boot/vmlinuz-$unr --initrd=$initrd --reuse-cmdline"
+    rlWatchdog "rhts-reboot" 600
+}
+
+#function to load kernel, then abruptly start the new kernel without issuing a shutdown
+kexec_boot_exec()
+{
+    rlRun "unr=$(uname -r)"
+    rlRun "initrd=/boot/initramfs-$unr.img"
+    rlRun "kexec -l /boot/vmlinuz-$unr --initrd=$initrd --reuse-cmdline"
+    rlRun "kexec -e -d"
+}
+
+rlJournalStart
+    rlPhaseStartSetup
+        install_fio
+        echo "REBOOTCOUNT=$REBOOTCOUNT"
+        if [ "$REBOOTCOUNT" -eq 0 ] ; then
+            PrepareReboot
+            kdump_prepare
+            sleep 5
+            FIO_Test "$device"
+            sleep 5
+            trigger_panic
+        elif [ "$REBOOTCOUNT" -eq 1 ] ; then
+            FIO_Test "$device"
+            sleep 5
+            kexec_boot_graceful
+        elif [ "$REBOOTCOUNT" -eq 2 ] ; then
+            FIO_Test "$device"
+            sleep 5
+            kexec_boot_exec
+        else
+            echo "Continue to Asserts"
+        fi
+    rlPhaseEnd
+
+rlPhaseStartTest
+    rlAssertEquals "System should reboot successfully" $REBOOTCOUNT 3
+    rlAssertExists  "$crashDir/vmcore"
+rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/storage/hw_raid/runtest.sh
+++ b/storage/hw_raid/runtest.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright (c) 2016 Red Hat, Inc. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#   Author: Marco Patalano <mpatalan@redhat.com>
+
+rhts-run-simple-test hw_raid "./main.sh"
+

--- a/storage/hw_raid/testinfo.desc
+++ b/storage/hw_raid/testinfo.desc
@@ -1,0 +1,10 @@
+Owner:           Marco Patalano <mpatalan@redhat.com>
+Name:            /tests-beaker/storage/hw_raid
+TestVersion:     0.1
+Path:            /mnt/tests/tests-beaker/storage/hw_raid
+Description:     This test will generate I/O using FIO at the device level and trigger a panic as well as kexec boot.
+License:		GPL v3
+RunFor:		storage
+Requires:	storage
+RepoRequires:    cki_lib
+RhtsRequires:	hw_raid


### PR DESCRIPTION
Tests created for HW RAID specifically for HPSA and SMARTPQI driver testing. Will be performed on specific servers (storageqe-29 - HPSA and storageqe-32 - SMARTPQI).