### PR TITLE
vm/kvm-unit-tests: Increase the timeout to prevent failures in Debug Kernel testing.

### DIFF
--- a/vm/kvm-unit-tests/x86_unittests.cfg
+++ b/vm/kvm-unit-tests/x86_unittests.cfg
@@ -167,6 +167,7 @@ arch = x86_64
 
 [port80]
 file = port80.flat
+timeout = 180
 
 [realmode]
 file = realmode.flat
@@ -277,7 +278,7 @@ file = vmx.flat
 extra_params = -cpu host,+vmx -append vmx_vmcs_shadow_test
 arch = x86_64
 groups = vmx
-timeout = 180
+timeout = 360
 
 [debug]
 file = debug.flat


### PR DESCRIPTION
These 2 tests (port80 and vmx_vmcs_shadow_test) are failing with timeout randomly when running with Debug Kernel installed. Increasing the timeout will prevent these failures.