### PR TITLE
vm/kvm-self-tests: Disable dirty_log_test since it is failing randomly

### DIFF
--- a/vm/kvm-self-tests/runtest.sh
+++ b/vm/kvm-self-tests/runtest.sh
@@ -102,6 +102,13 @@ function disableTests
                 mapfile -d $'\0' -t X86_64_TESTS < <(printf '%s\0' "${X86_64_TESTS[@]}" | grep -Pzv "x86_64/evmcs_test")
             fi
         fi
+
+        # Disabled s390x tests due to bugs
+        if [[ $hwpf == "s390x" ]]; then
+            # Disable test dirty_log_test
+            # due to https://bugzilla.redhat.com/show_bug.cgi?id=1741201
+            mapfile -d $'\0' -t ALLARCH_TESTS < <(printf '%s\0' "${ALLARCH_TESTS[@]}" | grep -Pzv "dirty_log_test")
+        fi
     fi
 
     # Disable tests for ARK Kernel (5.X)


### PR DESCRIPTION
As agreed with Thomas Huth will disable the test temporarily until the patch series which contains the fix get merged to the Kernel.