### PR TITLE
cpu/idle: resolve failure issues

### DIFF
--- a/cpu/idle/runtest.sh
+++ b/cpu/idle/runtest.sh
@@ -28,7 +28,14 @@ source $CDIR/../../cpu/common/libutil.sh
 function runtest
 {
     cki_run_cmd_pos "bash $CDIR/utils/idle-power-test.sh $CDIR/utils/busy.sh"
-    [ $? -eq 0 ] && return $CKI_PASS || return $CKI_FAIL
+    status=$?
+    if [ $status -eq 0 ]; then
+	return $CKI_PASS
+    elif [ $status -eq 2 ]; then
+	# maps to SKIP
+	return $CKI_UNSUPPORTED
+    fi
+    return $CKI_FAIL
 }
 
 function startup


### PR DESCRIPTION
Two issues are causing failures.  One is counter rollover.  The
second is that the power utilization improvement on low power
systems does not meet the expectations of this script.  Fix the
first issue by handling rollover fix the second by returning SKIP.