### PR TITLE
cki_lib/libcki.sh: make sure output from cki_set_reason is not lost

### DIFF
--- a/cki_lib/libcki.sh
+++ b/cki_lib/libcki.sh
@@ -83,7 +83,7 @@ function cki_report_result
             rlPass "$argv"
             ;;
         $CKI_FAIL)
-            rlFail "$argv"
+            rlFail "$argv $g_reason_fail"
             ;;
         #
         # NOTE: If a task is aborted or skipped, its cleanup should be done,


### PR DESCRIPTION
Currently, if cki_set_reason $CKI_FAIL "<msg>" is called before
calling cki_report_result, the <msg> is lost.

For example, insted of outputting:

    :: [ 12:26:29 ] :: [   FAIL   ] :: runtest() intel system is running: NONE

The failed test outputs the following:

    :: [ 12:22:13 ] :: [   FAIL   ] :: runtest()

Fix this by passing $g_reason_fail when call rlFail from
cki_report_result.