### PR TITLE
Add platform python and devel deps

### DIFF
--- a/storage/dm/common/Makefile
+++ b/storage/dm/common/Makefile
@@ -43,6 +43,7 @@ $(METADATA): Makefile
 	@echo "Requires:     python3" >> $(METADATA)
 	@echo "Requires:     python2-lxml" >> $(METADATA)
 	@echo "Requires:     python3-lxml" >> $(METADATA)
+	@echo "Requires:     platform-python-devel python-devel python3-devel" >> $(METADATA)
 	@echo "RepoRequires: cki_lib" >> $(METADATA)
 	@echo "RepoRequires: storage/include" >> $(METADATA)
 	@echo "Priority:     Normal" >> $(METADATA)

--- a/storage/iscsi/params/Makefile
+++ b/storage/iscsi/params/Makefile
@@ -55,6 +55,7 @@ $(METADATA): Makefile
 	@echo "Requires:        python3" >> $(METADATA)
 	@echo "Requires:        python2-lxml" >> $(METADATA)
 	@echo "Requires:        python3-lxml" >> $(METADATA)
+	@echo "Requires:     platform-python-devel python-devel python3-devel" >> $(METADATA)
 	@echo "RepoRequires:    cki_lib" >> $(METADATA)
 	@echo "RepoRequires:    storage/include" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)


### PR DESCRIPTION
Fix missing Python dependencies for storage/iscsi/params and storage/dm/common tests.
