### PR TITLE
Use vmlinuz-KVR when using grubby

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -383,7 +383,7 @@ function rpm_install()
 
   # Workaround for BZ 1698363
   if [[ "${ARCH}" == s390x ]] ; then
-    grubby --set-default /boot/"${KVER}" > /dev/null && zipl > /dev/null
+    grubby --set-default /boot/vmlinuz-"${KVER}" && zipl
     cki_print_success "Grubby workaround for s390x completed"
   fi
 


### PR DESCRIPTION
When using `grubby --set-default`, the argument must be in the
form of `vmlinuz-KVR` instead of just `KVR`. Without this change,
the kernel won't show up as the primary kernel at boot time. The
originally installed kernel will boot instead.

Also, remove the `/dev/null` redirect so we can see errors from
`grubby` and `zipl` in the future.

Fixes FASTMOVING-1315.

Signed-off-by: Major Hayden <major@redhat.com>