### PR TITLE
vm/kvm-unit-tests: Allow KVM Unit Tests to run on ARK

### DIFF
--- a/vm/kvm-unit-tests/runtest.sh
+++ b/vm/kvm-unit-tests/runtest.sh
@@ -137,6 +137,8 @@ fi
 # set the qemu-kvm path
 if [ -e /usr/libexec/qemu-kvm ]; then
     export QEMU="/usr/libexec/qemu-kvm"
+elif [ -e /usr/bin/qemu-kvm ]; then
+    export QEMU="/usr/bin/qemu-kvm"
 fi
 
 if [ -z "$QEMU" ]; then

--- a/vm/kvm-unit-tests/x86_unittests.cfg
+++ b/vm/kvm-unit-tests/x86_unittests.cfg
@@ -278,7 +278,7 @@ file = vmx.flat
 extra_params = -cpu host,+vmx -append vmx_vmcs_shadow_test
 arch = x86_64
 groups = vmx
-timeout = 360
+timeout = 720
 
 [debug]
 file = debug.flat


### PR DESCRIPTION
The QEMU binary is in a different location in Fedora and RHEL, updating the script to account for that.
Also updating the timeout for vmx_vmcs_shadow_test test since it still failed for Debug Kernel.