### PR TITLE
cpu/driver: handle older intel systems which do not have pstate support

### DIFF
--- a/cpu/driver/runtest.sh
+++ b/cpu/driver/runtest.sh
@@ -25,6 +25,25 @@ TMPDIR=/var/tmp/$(date +"%Y%m%d%H%M%S")
 
 source $CDIR/../../cpu/common/libutil.sh
 
+NON_PSTATE_PROCESSORS="26 31 46"
+skip_pstate()
+{
+    typeset model=$(lscpu | grep Model: | awk '{print $2}')
+    if [ -z "$model" ]; then
+	cki_log "unable to determine cpu model"
+	return 1
+    fi
+
+    for m in $NON_PSTATE_PROCESSORS; do
+	if [ $m -eq $model ]; then
+	    cki_log "model: $model - does not support intel_pstate"
+	    return 1
+	fi
+    done
+
+    return 0
+}
+
 function verify_intel_cpufreq_driver
 {
     typeset driver=$1
@@ -33,6 +52,17 @@ function verify_intel_cpufreq_driver
 
     typeset vendor=$(dmidecode -t 0 | grep Vendor: | \
                      cut -d: -f 2 | awk '{print tolower($1)}')
+
+    # older systems do not support intel pstate
+    skip_pstate
+    if [ $? -eq 1 ]; then
+	if [ $driver != "acpi-cpufreq" ]; then
+	    cki_log "intel (non-pstate) system is running: $driver"
+	    return $CKI_FAIL
+	fi
+	cki_log "intel system is running: $driver"
+	return $CKI_PASS
+    fi
 
     if [[ $driver != "intel_pstate" ]]; then
 	if [ "$vendor" = "lenovo" ]; then


### PR DESCRIPTION
On some older intel systems the intel_pstate driver is not supported.
We expect those systems to be running acpi-cpufreq.  Avoid returning
FAIL in those cases.