### PR TITLE
fs/xfs/xfstests: skip generic/402 for now

### DIFF
--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -4,3 +4,4 @@ generic/139
 generic/394
 generic/471
 generic/427
+generic/402


### PR DESCRIPTION
As the patch series for this test do not go into upstream
stable trees, and have not yet landed into RHEL trees.

Skip it for now, after all fixed we can pull it back.

Signed-off-by: Murphy Zhou <xzhou@redhat.com>