### PR TITLE
misc/module-load: temporarily remove cifs from RHEL8

### DIFF
--- a/misc/module-load/modules.rhel8
+++ b/misc/module-load/modules.rhel8
@@ -33,7 +33,6 @@ ceph
 ch
 chacha20_generic
 chacha20poly1305
-cifs
 cmac
 cmtp
 cramfs


### PR DESCRIPTION
The cifs module fails to unload with a "FATAL: Module gcm is builtin"
error.  Temporarily remove cifs from modules.rhel8 until RHBZ 1767094
is resolved.