### PR TITLE
Remove ipmi event simulation

### DIFF
--- a/ipmi/stress/ipmitool-loop/runtest.sh
+++ b/ipmi/stress/ipmitool-loop/runtest.sh
@@ -55,7 +55,6 @@ rlJournalStart
     for i in $(seq 0 10); do
     rlPhaseStartTest
         rlRun "ipmitool sel clear"
-        rlRun "ipmitool event 1"
         rlRun "ipmitool sel list"
         rlRun "ipmitool chassis selftest"
         rlRun "ipmitool chassis status"


### PR DESCRIPTION
On some machines, a warning event may cross the threshold and physically bring down the machines