### PR TITLE
serge-testuite: sync with downstream

### DIFF
--- a/packages/selinux-policy/serge-testsuite/Makefile
+++ b/packages/selinux-policy/serge-testsuite/Makefile
@@ -61,6 +61,8 @@ $(METADATA): Makefile
 	@echo "Requires:        git" >> $(METADATA)
 	@echo "Requires:        grep" >> $(METADATA)
 	@echo "Requires:        ipsec-tools" >> $(METADATA)
+	@echo "Requires:        keyutils-libs-devel" >> $(METADATA)
+	@echo "Requires:        libbpf-devel" >> $(METADATA)
 	@echo "Requires:        libibverbs-devel" >> $(METADATA)
 	@echo "Requires:        libselinux" >> $(METADATA)
 	@echo "Requires:        libselinux-devel" >> $(METADATA)


### PR DESCRIPTION
This patch forward ports the following downstream commits:
752c8d465 Sanity/serge-testsuite: fix for debug kernels
2cb1b8364 Sanity/serge-testsuite: enable the keys test
d303acc51 Sanity/serge-testsuite: drop merged pull request
8d683ce84 Sanity/serge-testsuite: disable BPF tests on RHEL
14812ef47 Sanity/serge-testsuite: fix running on RHEL-5
b3296c139 Sanity/serge-testsuite: update upstream commit
688df0280 Sanity/serge-testsuite: update upstream ref and fix typos
e71832e7a Sanity/serge-testsuite: remove unnecessary RHEL-6 workaround