### PR TITLE
Add readme file for ltp tests and libraries: distribution/ltp-upstream/lite, distribution/ltp-upstream/include, distribution/ltp/lite, and distribution/ltp/include

### DIFF
--- a/distribution/ltp-upstream/include/README.md
+++ b/distribution/ltp-upstream/include/README.md
@@ -1,0 +1,11 @@
+# LTP upstream library
+Ported LTP include library for Beaker upstream testing. \
+Test Maintainer: [Memory Management](mailto:mm-qe@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'. For a complete detail, see PURPOSE file. 
+
+### Execute the test
+```bash
+$ make run
+```

--- a/distribution/ltp-upstream/lite/README.md
+++ b/distribution/ltp-upstream/lite/README.md
@@ -1,0 +1,11 @@
+# LTP upstream lite testsuite
+LTP upstream lite testsuite can be used to run a subset tests in the LTP testsuite that contains collection of tools for testing the Linux kernel, and for a quick test to check an installed base. The testsuite runs on Beaker upstream testing only. \
+Test Maintainer: [Memory Management](mailto:mm-qe@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'. For a complete detail, see https://github.com/linux-test-project/ltp. 
+
+### Execute the test
+```bash
+$ make run
+```

--- a/distribution/ltp/include/README.md
+++ b/distribution/ltp/include/README.md
@@ -1,0 +1,11 @@
+# LTP library
+Ported LTP include library for Beaker. \
+Test Maintainer: [Memory Management](mailto:mm-qe@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'. For a complete detail, see PURPOSE file. 
+
+### Execute the test
+```bash
+$ make run
+```

--- a/distribution/ltp/lite/README.md
+++ b/distribution/ltp/lite/README.md
@@ -1,0 +1,11 @@
+# LTP lite testsuite
+LTP lite testsuite can be used to run a subset tests in the LTP testsuite that contains collection of tools for testing the Linux kernel, and for a quick test to check an installed base. \
+Test Maintainer: [Memory Management](mailto:mm-qe@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. Test-specific dependencies will automatically be installed when executing 'make run'. For a complete detail, see https://github.com/linux-test-project/ltp. 
+
+### Execute the test
+```bash
+$ make run
+```


### PR DESCRIPTION
  Add readme file for ltp tests and libraries:
   - distribution/ltp-upstream/lite
   - distribution/ltp-upstream/include
   - distribution/ltp/lite
   - distribution/ltp/include