### PR TITLE
fs/xfs/xfstests: skip generic/374

### DIFF
--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -1,6 +1,7 @@
 generic/466
 generic/084
 generic/139
+generic/374
 generic/394
 generic/471
 generic/427


### PR DESCRIPTION
It's causing false alarm dmesg warning on debug kernel:

BUG: MAX_LOCKDEP_CHAIN_HLOCKS too low!

Signed-off-by: Murphy Zhou <xzhou@redhat.com>