### PR TITLE
Revert "misc/module-load: temporarily remove cifs from RHEL8"

### DIFF
--- a/misc/module-load/modules.rhel8
+++ b/misc/module-load/modules.rhel8
@@ -33,6 +33,7 @@ ceph
 ch
 chacha20_generic
 chacha20poly1305
+cifs
 cmac
 cmtp
 cramfs


### PR DESCRIPTION
This reverts commit 196088bcdbffc4b445db47d02d184fbb99a05a3c.

The kmod tool has been updated so it's no longer a fatal error to remove
a built-in driver [*], therefore cifs can be added back into the test.

[*] https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/?id=52a0ba82e1ad