### PR TITLE
fs/xfs/xfstests: blacklist MAX_LOCKDEP_CHAIN_HLOCKS

### DIFF
--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -1,7 +1,6 @@
 generic/466
 generic/084
 generic/139
-generic/374
 generic/394
 generic/471
 generic/427

--- a/filesystems/xfs/xfstests/runtest.sh
+++ b/filesystems/xfs/xfstests/runtest.sh
@@ -22,6 +22,8 @@ dmesg -c >/dev/null
 # Source the common test script helpers
 . /usr/bin/rhts_environment.sh
 
+echo "MAX_LOCKDEP_CHAIN_HLOCKS" >> /usr/share/rhts/falsestrings
+
 . ./dep-install.sh
 . ./misc.sh
 . ./devices.sh


### PR DESCRIPTION
For dmesg checking, this should mute the false alarm.

At the same time, bring generic/374 back.

Signed-off-by: xiangcai <jencce2002@gmail.com>