### PR TITLE
fs/xfs/xfstests: whitelist dmesg string MAX_LOCKDEP_CHAIN_HLOCKS

### DIFF
--- a/filesystems/xfs/xfstests/Makefile
+++ b/filesystems/xfs/xfstests/Makefile
@@ -96,6 +96,7 @@ $(METADATA): Makefile
 	@echo "Requires:     samba samba-client cifs-utils" >> $(METADATA)
 	@echo "Requires:     rpcbind nfs-utils" >> $(METADATA)
 	@echo "Requires:     lvm2 beakerlib" >> $(METADATA)
+	@echo "environment:  FAILUREFILENM=/usr/share/rhts/falsestrings" >> $(METADATA)
 	@echo "RhtsRequires: test(/kernel/filesystems/xfs/include)" >> $(METADATA)
 	rhts-lint $(METADATA)
 #	The include package takes care of all the dependencies

--- a/filesystems/xfs/xfstests/known_issues
+++ b/filesystems/xfs/xfstests/known_issues
@@ -1,7 +1,6 @@
 generic/466
 generic/084
 generic/139
-generic/374
 generic/394
 generic/471
 generic/427

--- a/filesystems/xfs/xfstests/runtest.sh
+++ b/filesystems/xfs/xfstests/runtest.sh
@@ -22,6 +22,9 @@ dmesg -c >/dev/null
 # Source the common test script helpers
 . /usr/bin/rhts_environment.sh
 
+mkdir -p /usr/share/rhts/
+echo "MAX_LOCKDEP_CHAIN_HLOCKS" >> /usr/share/rhts/falsestrings
+
 . ./dep-install.sh
 . ./misc.sh
 . ./devices.sh


### PR DESCRIPTION
After we swtich to run tests on debug kernel, it's easy to hit this
warning during dmesg check of beaker by random subcase of xfstests.
xfstests upstream has whitelist this string as it is a false alarm,
not a real issue.

We can't skip subcase which is hitting this warning because any
stressful subcase could hit this. So bring generic/374 back, which
was wrongly skipped when we first hit this warning.

This solution suggested by Rachel should work according to:
https://git.beaker-project.org/cgit/restraint/tree/plugins/report_result.d/01_dmesg_check#n29

Signed-off-by: xiangcai <jencce2002@gmail.com>