### PR TITLE
save and redirect perf test to log file,

### DIFF
--- a/packages/perf/internal-testsuite/runtest.sh
+++ b/packages/perf/internal-testsuite/runtest.sh
@@ -158,8 +158,9 @@ rlJournalStart
 			if check_whitelisted "$TEST_DESC"; then
 				rlLog "[ WHITELISTED ] :: $TEST_NUMBER: $TEST_DESC  (known issue)"
 			else
-				perf test -vv $TEST_NUMBER |& tee $TEST_NUMBER.log
+				perf test -vv $TEST_NUMBER &>  $TEST_NUMBER.log
 				RETVAL=$?
+				cat $TEST_NUMBER.log
 				RESULT=`tail -n 1 $TEST_NUMBER.log | awk -F':' '{print $NF}' | tr -d ' '`
 				printf "%8s -- %s\n" $RESULT "$line" | tee -a results.log
 				echo $RESULT | grep -qi FAIL


### PR DESCRIPTION
somehow piping to external prg (ex: tee) could cause race condition based on observation/debugging