### PR TITLE
Revert MAX_LOCKDEP_CHAIN_HLOCKS falsestrings

### DIFF
--- a/filesystems/xfs/xfstests/Makefile
+++ b/filesystems/xfs/xfstests/Makefile
@@ -96,7 +96,6 @@ $(METADATA): Makefile
 	@echo "Requires:     samba samba-client cifs-utils" >> $(METADATA)
 	@echo "Requires:     rpcbind nfs-utils" >> $(METADATA)
 	@echo "Requires:     lvm2 beakerlib" >> $(METADATA)
-	@echo "environment:  FAILUREFILENM=/usr/share/rhts/falsestrings" >> $(METADATA)
 	@echo "RhtsRequires: test(/kernel/filesystems/xfs/include)" >> $(METADATA)
 	rhts-lint $(METADATA)
 #	The include package takes care of all the dependencies

--- a/filesystems/xfs/xfstests/runtest.sh
+++ b/filesystems/xfs/xfstests/runtest.sh
@@ -22,9 +22,6 @@ dmesg -c >/dev/null
 # Source the common test script helpers
 . /usr/bin/rhts_environment.sh
 
-mkdir -p /usr/share/rhts/
-echo "MAX_LOCKDEP_CHAIN_HLOCKS" >> /usr/share/rhts/falsestrings
-
 . ./dep-install.sh
 . ./misc.sh
 . ./devices.sh


### PR DESCRIPTION
The dmesg falsestrings will now be set in the beginning of each recipe, this will apply to all beaker tasks. The MAX_LOCKDEP_CHAIN_HLOCKS string will be included as a falsestring. The current approach was causing false positives since the defaults were overwritten.