### PR TITLE
Make the jvm test more robust

### DIFF
--- a/jvm/runtest.sh
+++ b/jvm/runtest.sh
@@ -42,8 +42,16 @@ rlJournalStart
     rlRun -l "mvn archetype:generate  -DinteractiveMode=false  -DarchetypeGroupId=org.openjdk.jcstress \
               -DarchetypeArtifactId=jcstress-java-test-archetype  -DgroupId=org.sample \
               -DartifactId=test  -Dversion=1.0"
+    if [ $? -ne 0 ]; then
+        rhts-abort -t recipe
+        exit 0
+    fi
     rlRun -l "cd test"
     rlRun -l "mvn clean install"
+    if [ $? -ne 0 ]; then
+        rhts-abort -t recipe
+        exit 0
+    fi
     rlRun -l "java -jar target/jcstress.jar"
   rlPhaseEnd
 


### PR DESCRIPTION
The Maven call to install dependencies for the jvm test could fail due
to infrastructure problems. In those cases, the test should be aborted
so that infrastructure problems don't end up being marked as test
failures.

NOTE: this PR is only to use the PR bot that will run the tests, because I'm having trouble running the tests on Beaker (lack of Beaker-fu, most likely). The one that should probably be merged instead is https://github.com/CKI-project/tests-beaker/pull/459, which is already reviewed and approved.