### PR TITLE
Remove fs_fill from known issues

### DIFF
--- a/distribution/ltp-upstream/include/knownissue.sh
+++ b/distribution/ltp-upstream/include/knownissue.sh
@@ -134,8 +134,6 @@ function knownissue_filter()
 	tskip "huge.*" fatal
 	# Issue TBD
 	tskip "memfd_create03" unfix
-	# https://lore.kernel.org/linux-btrfs/4d97a9bb-864a-edd1-1aff-bdc9c8204100@redhat.com/T/#u 
-	tskip "fs_fill" unfix
 	# this case always make the beaker task abort with 'incrementing stop' msg
 	tskip "min_free_kbytes" fatal
 	# Issue TBD

--- a/distribution/ltp-upstream/lite/patches/disable-btrfs.patch
+++ b/distribution/ltp-upstream/lite/patches/disable-btrfs.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/tst_supported_fs_types.c b/lib/tst_supported_fs_types.c
+--- a/lib/tst_supported_fs_types.c	2020-02-07 09:02:45.954708393 +0100
++++ b/lib/tst_supported_fs_types.c	2020-02-07 09:04:01.476581594 +0100
+@@ -18,7 +18,6 @@
+ 	"ext3",
+ 	"ext4",
+ 	"xfs",
+-	"btrfs",
+ 	"vfat",
+ 	"exfat",
+ 	"ntfs",

--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -79,6 +79,7 @@ function ltp_test_build()
 	make install                        &> buildlog.txt  || if cat buildlog.txt;  then test_msg fail "install ltp failed"; fi
 	# Timing on systems with shared resources (and high steal time) is not accurate, apply patch for non bare-metal machines
 	patch -p1 < ../patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
+	patch -p1 < ../patches/disable-btrfs.patch
 	popd > /dev/null 2>&1
 
 	test_msg pass "LTP build/install successful"


### PR DESCRIPTION
It seems that `fs_fill` is working properly now, so no need to keep it in known issues. The exception seems to be when it runs on btrfs, so disable that filesystem.