### PR TITLE
Make kpkginstall compatible with RHEL5

### DIFF
--- a/cki_lib/libcki.sh
+++ b/cki_lib/libcki.sh
@@ -236,7 +236,7 @@ function cki_pd()
 function cki_debug
 {
     typeset -l s=$DEBUG
-    if [[ $s == @(yes|true) ]]; then
+    if [[ "$s" == "yes" || "$s" == "true" ]]; then
         export PS4='__DEBUG__: [$FUNCNAME@$BASH_SOURCE:$LINENO|$SECONDS]+ '
         set -x
     fi

--- a/distribution/kpkginstall/Makefile
+++ b/distribution/kpkginstall/Makefile
@@ -46,5 +46,5 @@ $(METADATA): Makefile
 	@echo "License:         GPL" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Requires:        make curl grubby tar binutils" >> $(METADATA)
+	@echo "Requires:        make curl grubby tar binutils yum-utils" >> $(METADATA)
 	@echo "RepoRequires:    cki_lib" >> $(METADATA)

--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -313,7 +313,7 @@ function copr_prepare()
 function download_install_package()
 {
   # If download of a package fails, report warn/abort -> infrastructure issue
-  if $YUM install --downloadonly -y $1 > /dev/null; then
+  if $YUM install --downloadonly -y $1 > /dev/null || yumdownloader -y $1 > /dev/null; then
     cki_print_success "Downloaded $1 successfully"
   else
     cki_abort_recipe "Failed to download ${1}!" WARN
@@ -462,22 +462,21 @@ else
   if [ -f /tmp/kpkginstall/KPKG_VAR_DEBUG ]; then
     valid_kernel_versions=(
       "${KVER}.debug"           # RHEL 7 style debug kernels
-      "${KVER}.${ARCH}.debug"   # RHEL 7 style debug kernels
       "${KVER}+debug"           # RHEL 8 style debug kernels
-      "${KVER}.${ARCH}+debug"   # RHEL 8 style debug kernels
     )
   else
+    KVER=$(uname -r | sed "s/.$(uname -i)//")
     valid_kernel_versions=(
       "${KVER}"
       "${KVER}.${ARCH}"
     )
   fi
   ckver=$(uname -r)
-  cki_print_info "Acceptable kernel version strings: ${valid_kernel_versions[@]} "
+  cki_print_info "Acceptable kernel version strings: ${valid_kernel_versions[*]} "
   cki_print_info "Running kernel version string:     ${ckver}"
 
   # Did we get the right kernel running after reboot?
-  if [[ ! " ${valid_kernel_versions[@]} " =~ " ${ckver} " ]]; then
+  if [[ ! " ${valid_kernel_versions[*]} " =~ " ${ckver} " ]]; then
     cki_abort_recipe "Kernel version after reboot (${ckver}) does not match expected version strings!" WARN
   fi
 


### PR DESCRIPTION
Older versions of bash don't support certain syntax, update cki_lib to make it compatible for rhel5. Default to yumdownloader command as --download option was added RHEL6 or later.