### PR TITLE
Add harness section for example.xml

### DIFF
--- a/example/example.xml
+++ b/example/example.xml
@@ -1,7 +1,7 @@
 <job retention_tag="scratch">
   <whiteboard>RHEL8 LTP</whiteboard>
   <recipeSet priority="Normal">
-    <recipe whiteboard="" role="RECIPE_MEMBERS" ks_meta="" kernel_options="" kernel_options_post="">
+    <recipe whiteboard="" role="RECIPE_MEMBERS" ks_meta="harness='restraint-rhts beakerlib'" kernel_options="" kernel_options_post="">
       <autopick random="false"/>
       <watchdog panic="ignore"/>
       <packages/>


### PR DESCRIPTION
Since we do rely on both beakerLib and restraint-rhts (soon to be removed), we should probably include the expected harness dependencies, will update to restraint vs restraint-rhts once legacy rhts commands
are removed.