### PR TITLE
blktests: update the blktests repository to fix the compiling issue on RHEL7

### DIFF
--- a/storage/blk/Makefile
+++ b/storage/blk/Makefile
@@ -32,7 +32,7 @@ export TEST=$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
 export TESTVERSION=1.0
 
 # The upsteam location of tests
-LOOKASIDE=https://github.com/osandov/blktests.git
+LOOKASIDE=https://github.com/yizhanglinux/blktests.git
 
 TARGETS	= blktests \
 	  runtest


### PR DESCRIPTION
I've sent the patch to upstream, but it still not merged.

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>