### PR TITLE
kdump: Check and install grubby

### DIFF
--- a/kdump/include/runtest.sh
+++ b/kdump/include/runtest.sh
@@ -370,7 +370,7 @@ PrepareKdump()
             # Kdump service will not be enabled if crashkernel=auto && system
             # memory is less the threshold required by kdump service.
             /bin/systemctl enable kdump.service || /sbin/chkconfig kdump on
-
+            rpm -q --quiet grubby || InstallPackages grubby
             Log "- Changing boot loader."
             {
                 /sbin/grubby                     \


### PR DESCRIPTION
grubby is not installed by default on F31.
To ensure crash memory is reserved properly on Fedora by updating kernel options by grubby, added a check and install grubby if it's not installed.

Verified on Beaker.
Signed-off-by: xiawu <xiawu@redhat.com>