### PR TITLE
Add dependency url for DCI xml

### DIFF
--- a/example/example.xml
+++ b/example/example.xml
@@ -19,6 +19,9 @@
       <task name="/distribution/check-install" role="STANDALONE"/>
       <task name="LTP" role="STANDALONE">
         <fetch url="https://github.com/CKI-project/tests-beaker/archive/master.zip#distribution/ltp-upstream/lite"/>
+        <dependencies>
+          <dependency url="https://github.com/linux-test-project/ltp/releases/download/20200120/ltp-full-20200120.tar.bz2"/>
+        </dependencies>
       </task>
     </recipe>
   </recipeSet>


### PR DESCRIPTION
Required for DCI testing, the dependency parameter will be used by the DCI client to mirror the tarball to the jumphost.