### PR TITLE
CKI: create a test wrapper for upstream kernel selftest

### DIFF
--- a/kselftests/Makefile
+++ b/kselftests/Makefile
@@ -1,0 +1,85 @@
+# Copyright (c) 2020 Red Hat, Inc. All rights reserved. This copyrighted material
+# is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General
+# Public License v.2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Author: Hangbin Liu <haliu@redhat.com>
+
+# The toplevel namespace within which the test lives.
+# FIXME: You will need to change this:
+TOPLEVEL_NAMESPACE=kernel
+
+# The name of the package under test:
+# FIXME: you wil need to change this:
+PACKAGE_NAME=
+
+# The path of the test below the package:
+# FIXME: you wil need to change this:
+RELATIVE_PATH=kselftests
+
+# Version of the Test. Used with make tag.
+export TESTVERSION=0.1
+
+# The combined namespace of the test.
+export TEST=/$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
+
+
+# A phony target is one that is not really the name of a file.
+# It is just a name for some commands to be executed when you
+# make an explicit request. There are two reasons to use a
+# phony target: to avoid a conflict with a file of the same
+# name, and to improve performance.
+.PHONY: all install download clean
+
+# executables to be built should be added here, they will be generated on the system under test.
+BUILT_FILES=
+
+# data files, .c files, scripts anything needed to either compile the test and/or run it.
+FILES=$(METADATA) runtest.sh Makefile PURPOSE
+
+run: $(FILES) build
+	./runtest.sh
+
+build: $(BUILT_FILES)
+	chmod a+x ./runtest.sh
+
+clean:
+	rm -f *~ *.rpm $(BUILT_FILES)
+
+# You may need to add other targets e.g. to build executables from source code
+# Add them here:
+
+
+# Include Common Makefile
+TEST_DIR=/mnt/tests$(TEST)
+INSTALL_DIR=$(DEST)$(TEST_DIR)
+METADATA=testinfo.desc
+
+# Generate the testinfo.desc here:
+$(METADATA): Makefile
+	@touch $(METADATA)
+# Change to the test owner's name
+	@echo "Owner:        Hangbin Liu <haliu@redhat.com>" > $(METADATA)
+	@echo "Name:         $(TEST)" >> $(METADATA)
+	@echo "Path:         $(TEST_DIR)"	>> $(METADATA)
+	@echo "License:      GPLv2" >> $(METADATA)
+	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
+	@echo "Description:  kselftests">> $(METADATA)
+	@echo "Type:         Tier1" >> $(METADATA)
+	@echo "Bug:          1704655" >> $(METADATA)
+	@echo "RunFor:       $(PACKAGE_NAME)" >> $(METADATA)
+# add any other packages for which your test ought to run here
+	@echo "Requires:     tar autoconf automake" >> $(METADATA)
+	@echo "Requires:     iproute-tc jq netsniff-ng" >> $(METADATA)
+	@echo "Requires:     clang valgrind" >> $(METADATA)
+	@echo "Requires:     $(PACKAGE_NAME)" >> $(METADATA)
+
+# You may need other fields here; see the documentation

--- a/kselftests/README.md
+++ b/kselftests/README.md
@@ -1,0 +1,21 @@
+# kselftest test
+This is a test wrapper for [kernel selftest](https://github.com/torvalds/linux/tree/master/tools/testing/selftests) to be run in beaker test environment.
+
+Test Maintainer: [Hangbin Liu](mailto:haliu@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies. There are no test-specific dependencies.
+
+### Execute the test
+```bash
+$ make run
+```
+
+### support tests
+bpf
+net
+net/forwarding
+tc-testing
+
+### unsupport tests
+livepatch: CONFIG_TEST_LIVEPATCH is not enabled on fedora

--- a/kselftests/include.sh
+++ b/kselftests/include.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+[ ! "$JOBID" ] && rm -rf logs && mkdir logs && export LOG_DIR="$PWD/logs"
+
+if [ ! "$JOBID" ]; then
+	RED='\E[1;31m'
+	GRN='\E[1;32m'
+	YEL='\E[1;33m'
+	RES='\E[0m'
+fi
+
+new_outputfile()
+{
+	[ "$JOBID" ] && mktemp /mnt/testarea/tmp.XXXXXX || mktemp $LOG_DIR/tmp.XXXXXX
+}
+
+setup_env()
+{
+	# install dependence
+	# save testing environment
+	# export our new variable
+	export PASS=0
+	export FAIL=0
+	export OUTPUTFILE=$(new_outputfile)
+}
+
+clean_env()
+{
+	# clean environment
+	# restore environment
+	unset PASS
+	unset FAIL
+}
+
+log()
+{
+	echo -e "\n[$(date '+%T')][$(whoami)@$(uname -r | cut -f 2 -d-)]# " | tee -a $OUTPUTFILE
+	echo -e "\n[  LOG: $1  ]" | tee -a $OUTPUTFILE
+}
+
+submit_log()
+{
+	for file in $@; do
+		[ "$JOBID" ] && rstrnt-report-log -l $file || cp $file $LOG_DIR/
+	done
+}
+
+test_pass()
+{
+	echo -e "\n:: [  PASS  ] :: Test '"$1"'" >> $OUTPUTFILE
+	if [ $JOBID ]; then
+		rstrnt-report-result "${TEST}/$1" "PASS"
+	else
+		echo -e "::::::::::::::::"
+		echo -e ":: [  ${GRN}PASS${RES}  ] :: Test '"${TEST}/$1"'"
+		echo -e "::::::::::::::::\n"
+	fi
+}
+
+test_fail()
+{
+	SCORE=${2:-$FAIL}
+	echo -e ":: [  FAIL  ] :: Test '"$1"'" >> $OUTPUTFILE
+	if [ $JOBID ]; then
+		rstrnt-report-result "${TEST}/$1" "FAIL" "$SCORE"
+	else
+		echo -e ":::::::::::::::::"
+		echo -e ":: [  ${RED}FAIL${RES}  ] :: Test '"${TEST}/$1"' FAIL $SCORE"
+		echo -e ":::::::::::::::::\n"
+	fi
+}
+
+test_warn()
+{
+	echo -e "\n:: [  WARN  ] :: Test '"$1"'" | tee -a $OUTPUTFILE
+	if [ $JOBID ]; then
+		rstrnt-report-result "${TEST}/$1" "WARN"
+	else
+		echo -e "\n:::::::::::::::::"
+		echo -e ":: [  ${YEL}WARN${RES}  ] :: Test '"${TEST}/$1"'"
+		echo -e ":::::::::::::::::\n"
+	fi
+}
+
+test_pass_exit()
+{
+	test_pass $1
+	exit 0
+}
+
+test_fail_exit()
+{
+	test_fail $1
+	exit 1
+}
+
+test_warn_exit()
+{
+	test_fail $1
+	exit 1
+}
+
+# Usage: run command [return_value]
+run()
+{
+	cmd=$1
+	# FIXME: only support zero or none zero, doesn't support 2-10, or 2,3,4
+	exp=${2:-0}
+	echo -e "\n[$(date '+%T')][$(whoami)@$(uname -r | cut -f 2 -d-)]# '"$cmd"'" | tee -a $OUTPUTFILE
+	# FIXME: how should we handle if there are lots of output for the cmd,
+	# and we only care the return value
+	eval "$cmd" > >(tee -a $OUTPUTFILE)
+	ret=$?
+	if [ "$exp" -eq "$ret" ];then
+		let PASS++
+		echo -e ":: [  ${GRN}PASS${RES}  ] :: Command '"$cmd"' (Expected $exp, got $ret, score $PASS)" | tee -a $OUTPUTFILE
+		return 0
+	else
+		let FAIL++
+		echo -e ":: [  ${RED}FAIL${RES}  ] :: Command '"$cmd"' (Expected $exp, got $ret, score $FAIL)" | tee -a $OUTPUTFILE
+		return 1
+	fi
+}
+
+# Usage: watch command timeout [signal]
+watch()
+{
+	command=$1
+	timeout=$2
+	single=${3:-9}
+	now=`date '+%s'`
+	after=`date -d "$timeout seconds" '+%s'`
+
+	eval "$command" &
+	pid=$!
+	while true; do
+		now=`date '+%s'`
+
+		if ps -p $pid; then
+			if [ "$after" -gt "$now" ]; then
+				sleep 10
+			else
+				log "command (# $command) still alive, kill it"
+				kill -$single $pid
+				break
+			fi
+		else
+			log "command (# $command) exit itself"
+			break
+		fi
+	done
+}

--- a/kselftests/runtest.sh
+++ b/kselftests/runtest.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /kernel/networking/kselftests
+#   Description: kselftests
+#   Author: Hangbin Liu <haliu@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Global parameters
+# DEBUG: enable debug or not, default is true
+# CHECK_UNINVES: also check uninvestigated tests result, default is false
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+. ./include.sh
+#-------------------- Setup --------------------
+EXEC_DIR="$PWD/kselftests"
+SKIP=4
+
+# Test items
+LOG_ONCE=0
+TEST_ITEMS=${TEST_ITEMS:-"net net/forwarding bpf tc-testing"}
+
+DEFAULT_IFACE=$(ip route | awk '/default/{match($0,"dev ([^ ]+)",M); print M[1]; exit}')
+TOTAL_MEM=$(free -m | awk '/Mem/ {print $2}')
+
+skip_tests=(
+# CONFIG_TEST_BPF is not set
+test_bpf.sh
+)
+
+# Tests in this list need large memory
+large_mem_tests=(
+tc-tests/filters/concurrency.json
+tc-tests/filters/tests.json
+)
+
+debug_info()
+{
+	[ ${LOG_ONCE} -eq 0 ] && \
+		log "$(rpm -q bpftool clang llvm iproute iproute-tc)" && \
+		LOG_ONCE=1
+
+	if [ "$DEBUG" ]; then
+		run "ip link show"
+		run "bpftool prog show"
+		run "iptables -L"
+		run "ip6tables -L"
+	fi
+}
+
+clean_env()
+{
+	# log the link before clean
+	debug_info
+	modprobe -r ipip
+	modprobe -r vxlan
+	modprobe -r geneve
+	modprobe -r ip_gre
+	modprobe -r ip6_gre
+	modprobe -r ip6_vti
+	modprobe -r ip6_tunnel
+	modprobe -r veth
+	# Looks fedora doesn't has this module
+	# modprobe -r netdevsim
+	ip -a netns del
+	sleep 2
+	debug_info
+}
+
+# usage: check_skipped_tests test_name "${skip_test[@]}"
+check_skipped_tests()
+{
+	local match="$1"
+	[[ " ${skip_tests[*]} " == *" $match "* ]] && return 0
+	[ $TOTAL_MEM -lt 8000 ] && [[ " ${large_mem_tests[*]} " == *" $match "* ]] && return 0
+	# skip the test if it not exist for backward compatibility
+	[ ! -f $match ] && return 0
+	return 1
+}
+
+run_test()
+{
+	local test_name=$1
+
+	# some times the test may fail with resource issue, re-run it would
+	# pass
+	./${test_name} &> $OUTPUTFILE
+	local ret=$?
+	if [ $ret -ne 0 ]; then
+		./${test_name} &>> $OUTPUTFILE
+	else
+		return $ret
+	fi
+}
+
+# For upstream kselftest testing, we need a pre-build selftest tar ball url
+install_kselftests()
+{
+	[ ! "$selftests_url" ] && log "no selftests_url" && return 1
+	wget --no-check-certificate $selftests_url -O kselftest.tar.gz
+	tar zxf kselftest.tar.gz
+	[ -f kselftest/run_kselftest.sh ] && return 0 || return 1
+}
+
+install_netsniff()
+{
+	dnf install -y jq netsniff-ng
+	which mausezahn && return 0 || return 1
+}
+
+install_smcroute()
+{
+	which smcroute && return 0
+	yum install -y libcap-devel
+	smc_v="2.4.4"
+	wget https://github.com/troglobit/smcroute/releases/download/${smc_v}/smcroute-${smc_v}.tar.gz
+	tar zxf smcroute-${smc_v}.tar.gz
+	pushd smcroute-${smc_v}
+	./autogen.sh && ./configure --sysconfdir=/etc --localstatedir=/var && make && make install
+	popd
+	which smcroute && return 0 || return 1
+}
+
+# @arg1: test name
+get_test_list()
+{
+	local name=$1
+	local start_line end_line test_list
+
+	pushd $EXEC_DIR &> /dev/null
+
+	if [ $name == "net/forwarding" ]; then
+		test_list=$(find net/forwarding -maxdepth 1 -perm -g=x -type f | sed "s/net\/forwarding\///")
+	else
+		start_line=$(grep -n "in $name" run_kselftest.sh | cut -f1 -d:)
+		sed -n "${start_line},$ p" run_kselftest.sh > ${name}.list
+		end_line=$(grep -n "cd \$ROOT" ${name}.list | head -n1 | cut -f1 -d:)
+		sed -i "${end_line},$ d" ${name}.list
+		sed -i "1,3 d" ${name}.list
+		test_list=$(cat ${name}.list | awk -F'"' '{print $2}')
+	fi
+	popd &> /dev/null
+	echo $test_list
+}
+
+check_result()
+{
+	local num=$1
+	local total_num=$2
+	local test_folder=$3
+	local test_name=$4
+	local test_result=$5
+
+	if [ "$test_result" -eq 0 ]; then
+		test_pass "${num}..${total_num} selftests: ${test_folder}: ${test_name} [PASS]"
+	elif [[ " ${pending_tests[*]} " == *" $test_name "* ]] && [ ! $CHECK_UNINVES ]; then
+		test_pass "${num}..${total_num} selftests: ${test_folder}: ${test_name} [WAIVE]"
+	elif [[ " ${uninves_tests[*]} " == *" $test_name "* ]] && [ ! $CHECK_UNINVES ]; then
+		test_pass "${num}..${total_num} selftests: ${test_folder}: ${test_name} [WAIVE]"
+	elif [ "$test_result" -eq $SKIP ]; then
+		test_pass "${num}..${total_num} selftests: ${test_folder}: ${test_name} [SKIP]"
+	else
+		test_fail "${num}..${total_num} selftests: ${test_folder}: ${test_name} [FAIL]"
+	fi
+
+	return $test_result
+}
+
+do_net_config()
+{
+	# Fix some known issues
+	# rm 0x10 for fib_rule_tests.sh due to bz1480136
+	# FIXME: should we restore it back after finishing test?
+	sed -i "/0x10/d" /etc/iproute2/rt_dsfield
+	# FIXME: sleep 5s before do IPv6 "Using route with mtu metric" test to
+	# pass it. Not sure why ping would fail if not sleep some seconds, need to check
+	sed -i "/via 2001:db8:101::2 mtu 1300/a\\\\tsleep 5" fib_tests.sh
+	# need to be run on bare metal machines, or set -C 0 when run on VM
+	sed -i 's/-C [0-9]/-C 0/g' msg_zerocopy.sh
+	# fou is not enabled on RHEL
+	sed -i 's/kci_test_encap_fou /#kci_test_encap_fou /' rtnetlink.sh
+	# ip_defrag.sh need setting net.netfilter.nf_conntrack_frag6_high_thresh
+	modprobe nf_conntrack_ipv6
+	# pmtu.sh will return 1 for skiped tests, remove fou,gue tests
+	sed -i '/^\tpmtu_ipv[4,6]_fou[4,6]_exception/d' pmtu.sh
+	sed -i '/^\tpmtu_ipv[4,6]_gue[4,6]_exception/d' pmtu.sh
+	sed -i 's/exitcode=1/[ $ret -ne 2 ] \&\& exitcode=1/' pmtu.sh
+}
+
+do_net_forwarding_config()
+{
+	which tc || dnf install -q -y iproute-tc
+	install_netsniff || { test_fail "install netsniff for forwarding test failed" && return 1; }
+	install_smcroute || { test_fail "install smcrouted for forwarding test failed" && return 1; }
+	cp forwarding.config.sample forwarding.config
+}
+
+do_bpf_config() { return 0; }
+
+do_tc_test()
+{
+	# Start tc test
+	local item="tc-testing"
+	local act_tests=$(ls -d tc-tests/actions/*.json)
+	local fil_tests=$(ls -d tc-tests/filters/*.json)
+	local qdi_tests=$(ls -d tc-tests/qdiscs/*.json)
+	local total_tests="$act_tests $fil_tests $qdi_tests"
+	local total_num=$(echo ${total_tests} | wc -w)
+	local nfail=0 nskip=0 ret=0
+
+	# prepare evn
+	rpm -q clang || dnf install -y clang valgrind
+	modprobe -r veth
+	cd $EXEC_DIR/tc-testing
+
+	# extend test timeout
+	sed -i '/TIMEOUT/s/12/180/' tdc_config.py
+	# to build action.o for test tc-tests/actions/bpf.json
+	run "clang -target bpf -c bpf/action.c -o bpf/action.o"
+
+	for name in ${total_tests}; do
+		num=$(($num + 1))
+		local OUTPUTFILE=$(new_outputfile)
+
+		check_skipped_tests "${name}" && \
+			test_pass "${num}..${total_num} selftests: ${item}: ${name} Skip" && continue
+
+		echo ${tc_tests[$num - 1]} | grep -qP "tests\.json|concurrency\.json"  && extra_p="-d $DEFAULT_IFACE" || extra_p=""
+		./tdc.py -f ${name} $extra_p &> $OUTPUTFILE
+		ret=$?
+		if grep -q "not ok" $OUTPUTFILE; then
+			check_result $num $total_num ${item} ${name} 1
+			nfail=$((nfail+1))
+		elif grep -q "# skipped -" $OUTPUTFILE; then
+			check_result $num $total_num ${item} ${name} 4
+			nskip=$((nskip+1))
+		elif grep -q "Traceback" $OUTPUTFILE; then
+			check_result $num $total_num ${item} ${name} 4
+			nskip=$((nskip+1))
+		else
+			check_result $num $total_num ${item} ${name} $ret
+		fi
+	done
+
+	echo "${item}: total $total_num, failed $nfail, skipped $nskip"
+}
+
+#-------------------- Start Test --------------------
+install_kselftests || { test_fail "install kselftests failed" && exit 1; }
+
+run "uname -r"
+clean_env
+submit_log "$EXEC_DIR/run_kselftest.sh"
+
+for item in $TEST_ITEMS; do
+	if [ "$item" == "tc-testing" ]; then
+		do_tc_test
+		continue
+	fi
+
+	_item=$(echo $item | tr -s "/-" "_")
+	total_tests=$(get_test_list ${item})
+	total_num=$(echo ${total_tests} | wc -w)
+	nfail=0 num=0 name=""
+
+	cd $EXEC_DIR/$item
+	do_${_item}_config || continue
+
+	for name in ${total_tests}; do
+		num=$(($num + 1))
+		OUTPUTFILE=$(new_outputfile)
+
+		check_skipped_tests "${name}" && \
+			test_pass "${num}..${total_num} selftests: ${item}: ${name} Skip" && continue
+
+		dmesg -C
+
+		run_test ${name}
+		ret=$?
+
+		echo -e "\n=== Dmesg result ===" >> $OUTPUTFILE
+		dmesg >> $OUTPUTFILE
+
+		check_result $num $total_num ${item} ${name} $ret || \
+			nfail=$((nfail+1))
+		clean_env
+	done
+
+	echo "${item}: total $total_num, failed $nfail"
+done
+
+#-------------------- Clean Up --------------------


### PR DESCRIPTION
Currently we only support bpf, net, forwarding, tc tests

Signed-off-by: Hangbin Liu <haliu@redhat.com>