### PR TITLE
networking/ipsec: remove throughput test

### DIFF
--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
@@ -190,7 +190,8 @@ rlJournalStart
 
 	rlPhaseStartTest "$SUB_PARAM"
 		data_tests
-		perf_tests
+		# comment perf_tests for CKI-project test, as CKI should be only running basic Tier0/Tier1 sanity level testing
+		# perf_tests
 		cp /proc/crypto proc_crypto
 		rlFileSubmit proc_crypto
 	rlPhaseEnd


### PR DESCRIPTION
Since CKI should be only running basic Tier0/Tier1 sanity level testing,
comment perf_test

Signed-off-by: Xiumei Mu <xmu@redhat.com>