### PR TITLE
kdump: Install crash/kexec-tools from F32

### DIFF
--- a/kdump/kdump-sysrq-c/runtest.sh
+++ b/kdump/kdump-sysrq-c/runtest.sh
@@ -60,6 +60,10 @@ EOF
         else
             CrashCommand "" "${vmlinux}" "${vmcore}"
         fi
+
+        # Clear the vmcore file at the end of test
+        Log "Test Cleanup: Remove ${vmcore}"
+        rm -f "${vmcore}"
     fi
 }
 


### PR DESCRIPTION
1. Allow upgrading Kdump/Crash to latest F32 build
- This would hopefully solve the issue of userspace tools support on upstream kernels.
- Systemd/Dracut will be upgraded along with kexec-tools to avoid any service dependencies.
- Hardcode '--releasever=32' for now 

2. Add 2 options UPGRADE_FC_KDUMP/UPGRADE_FC_CRASH to
  enable/disable package upgarding.
- By default, both options are 'true'.
- Kexec-tools/Crash will not be upgraded to F32 build if UPGRADE_FC_KDUMP or UPGRADE_FC_CRASH is set to be false.
- This is just in case any regression introduced in latest F32 userspace builds.
- Applied to FC only.

3. Other minor fixes
- Kdump service is not restarted after reseting the default config
- Check if dmidecode is installed before generating bios log.
- Cleanup vmcores at the end of test
- Log the dracut/systemd pkg versions as well

Signed-off-by: xiawu <xiawu@redhat.com>