### PR TITLE
audit-testsuite: pin to known-good upstream commit

### DIFF
--- a/packages/audit/audit-testsuite/runtest.sh
+++ b/packages/audit/audit-testsuite/runtest.sh
@@ -36,7 +36,7 @@ PACKAGE="kernel"
 GIT_URL=${GIT_URL:-"https://github.com/linux-audit/audit-testsuite.git"}
 
 # Optional test paramenter - branch containing tests.
-GIT_BRANCH=${GIT_BRANCH:-"master"}
+GIT_BRANCH=${GIT_BRANCH:-"f92d3bee7bdd6cc3fc0667449a683d1de1e66db0"}
 
 # Optional test parameter - list to tests to be executed.
 TESTS=${TESTS:-""}


### PR DESCRIPTION
Latest master has some new tests that are failing on RHEL-7. Pin to a
last upstream commit that works until the test is adapted. This will
also prevent new false failures from appearing when upstream repo is
updated with more tests.

Cc: @The-Mule