### PR TITLE
kselftest: use CKI_SELFTEST_URL

### DIFF
--- a/kselftests/include.sh
+++ b/kselftests/include.sh
@@ -81,6 +81,18 @@ test_warn()
 	fi
 }
 
+test_skip()
+{
+	echo -e "\n:: [  SKIP  ] :: Test '"$1"'" | tee -a $OUTPUTFILE
+	if [ $JOBID ]; then
+		rstrnt-report-result "${TEST}/$1" SKIP 0
+	else
+		echo -e "\n:::::::::::::::::"
+		echo -e ":: [  ${YEL}SKIP${RES}  ] :: Test '"${TEST}/$1"'"
+		echo -e ":::::::::::::::::\n"
+	fi
+}
+
 test_pass_exit()
 {
 	test_pass $1
@@ -97,6 +109,12 @@ test_warn_exit()
 {
 	test_fail $1
 	exit 1
+}
+
+test_skip_exit()
+{
+	test_skip $1
+	exit 0
 }
 
 # Usage: run command [return_value]

--- a/kselftests/runtest.sh
+++ b/kselftests/runtest.sh
@@ -114,8 +114,7 @@ run_test()
 # For upstream kselftest testing, we need a pre-build selftest tar ball url
 install_kselftests()
 {
-	[ ! "$selftests_url" ] && log "no selftests_url" && return 1
-	wget --no-check-certificate $selftests_url -O kselftest.tar.gz
+	wget --no-check-certificate $CKI_SELFTEST_URL -O kselftest.tar.gz
 	tar zxf kselftest.tar.gz
 	[ -f kselftest/run_kselftest.sh ] && return 0 || return 1
 }
@@ -264,7 +263,8 @@ do_tc_test()
 }
 
 #-------------------- Start Test --------------------
-install_kselftests || { test_fail "install kselftests failed" && exit 1; }
+[ ! "$CKI_SELFTEST_URL" ] && test_skip_exit "No CKI_SELFTEST_URL found"
+install_kselftests || test_fail_exit "install kselftests failed"
 
 run "uname -r"
 clean_env


### PR DESCRIPTION
We should use env CKI_SELFTEST_URL as the download URL.
If not found, the test should skip instead of warn.

Signed-off-by: Hangbin Liu <haliu@redhat.com>