### PR TITLE
Audit testsuite rhel7 fix

### DIFF
--- a/packages/audit/audit-testsuite/runtest.sh
+++ b/packages/audit/audit-testsuite/runtest.sh
@@ -36,7 +36,7 @@ PACKAGE="kernel"
 GIT_URL=${GIT_URL:-"https://github.com/linux-audit/audit-testsuite.git"}
 
 # Optional test paramenter - branch containing tests.
-GIT_BRANCH=${GIT_BRANCH:-"master"}
+GIT_BRANCH=${GIT_BRANCH:-"ece04ca5517449930cafdddd8c076a258d0e0faf"}
 
 # Optional test parameter - list to tests to be executed.
 TESTS=${TESTS:-""}


### PR DESCRIPTION
New tests were added recently to audit-testsuite (kernel audit upstream testsuite for audit used by this beaker tests). Two of them are not RHEL-7 compatible and need to be filtered out, they run correctly on RHEL-8.