### PR TITLE
ipsec_baisc_netns: sleep longer for slow machines

### DIFF
--- a/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
+++ b/networking/ipsec/ipsec_basic/ipsec_basic_netns/runtest.sh
@@ -39,10 +39,10 @@ ipsec_stat(){
 
 	if [ $when == before ]; then
 		rlRun "tcpdump -i br0 > $packet &"
-		rlRun "sleep 0.5"
+		rlRun "sleep 2"
 	fi
 	if [ $when == after ];then
-		rlRun "pkill tcpdump; sleep 1"
+		rlRun "pkill tcpdump; sleep 2"
 		rlRun "cat $packet | egrep 'AH|ESP|IPComp' | head -n5"
 		rm -f $packet
 	fi
@@ -78,11 +78,11 @@ data_tests(){
 	rlLog "***** tcp ******"
 	ipsec_stat tcp before
 	rlRun "$HB socat -u -$TEST_VER tcp-l:$tcpport open:tcprecv,creat &"
-	rlRun "sleep 1"
+	rlRun "sleep 2"
 	bytes_1M="1048576" # (1M) for tcp test
 	[ $TEST_VER -eq 4 ] && rlRun "$HA socat -u -4 /dev/zero,readbytes=$bytes_1M tcp-connect:${HB_IP[$TEST_VER]}:$tcpport"
 	[ $TEST_VER -eq 6 ] && rlRun "$HA socat -u -6 /dev/zero,readbytes=$bytes_1M tcp-connect:[${HB_IP[$TEST_VER]}]:$tcpport"
-	rlRun "sleep 2"
+	rlRun "sleep 4"
 	rlRun "ls -l tcprecv | grep $bytes_1M" 0 "tcp should receive $bytes_1M bytes, received `ls -l tcprecv | awk '{print $5}'` bytes"
 	rm -f tcprecv
 	ipsec_stat tcp after
@@ -90,10 +90,10 @@ data_tests(){
 	for size in $msg_size 20000;do
 		ipsec_stat udp before
 		rlRun "$HB socat -u -$TEST_VER udp-l:$udpport open:udprecv,creat &"
-		rlRun "sleep 1"
+		rlRun "sleep 2"
 		[ $TEST_VER -eq 4 ] && rlRun "$HA socat -u -4 /dev/zero,readbytes=$size udp-sendto:${HB_IP[$TEST_VER]}:$udpport"
 		[ $TEST_VER -eq 6 ] && rlRun "$HA socat -u -6 /dev/zero,readbytes=$size udp-sendto:[${HB_IP[$TEST_VER]}]:$udpport"
-		rlRun "sleep 2"
+		rlRun "sleep 4"
 		rlRun "ls -l udprecv | grep $size" 0 "udp should receive $size bytes, received `ls -l udprecv | awk '{print $5}'` bytes"
 		rlRun "pkill socat"
 		rm -f udprecv
@@ -102,10 +102,10 @@ data_tests(){
 	rlLog "***** sctp ******"
 	ipsec_stat sctp before
 	rlRun "$HB socat -u -$TEST_VER sctp-listen:$sctpport open:sctprecv,creat &"
-	rlRun "sleep 1"
+	rlRun "sleep 2"
 	[ $TEST_VER -eq 4 ] && rlRun "$HA socat -u -4 /dev/zero,readbytes=2000 sctp:${HB_IP[$TEST_VER]}:$sctpport"
 	[ $TEST_VER -eq 6 ] && rlRun "$HA socat -u -6 /dev/zero,readbytes=2000 sctp:[${HB_IP[$TEST_VER]}]:$sctpport"
-	rlRun "sleep 2"
+	rlRun "sleep 4"
 	rlRun "ls -l sctprecv | grep 2000" 0 "sctp should receive 2000 bytes, received `ls -l sctprecv | awk '{print $5}'` bytes"
 	rm -f sctprecv
 	ipsec_stat sctp after


### PR DESCRIPTION
Current sleep time is not enought on some slow machines like s390x,
so sleep double time.