### PR TITLE
Move static lookaside files to s3://cki-artifacts/lookaside/static

### DIFF
--- a/jvm/dacapobench/runtest.sh
+++ b/jvm/dacapobench/runtest.sh
@@ -29,7 +29,7 @@
 rlJournalStart
 # Run DaCapo Benchmarks
  rlPhaseStartTest
-    rlRun -l "wget https://cki-artifacts.s3.us-east-2.amazonaws.com/lookaside/dacapo-9.12-MR1-bach.jar"
+    rlRun -l "wget https://cki-artifacts.s3.us-east-2.amazonaws.com/lookaside/static/dacapo-9.12-MR1-bach.jar"
         if [ $? -ne 0 ]; then
             rstrnt-abort -t recipe
             exit 0

--- a/storage/lvm/thinp/sanity/Makefile
+++ b/storage/lvm/thinp/sanity/Makefile
@@ -37,7 +37,7 @@ build: $(METADATA) $(TARGET)
 
 $(TARGET):
 	# Use lookaside location for iozone3 dependency
-	wget --tries=10 http://cki-artifacts.s3.us-east-2.amazonaws.com/lookaside/$(TARGET).tar.gz
+	wget --tries=10 http://cki-artifacts.s3.us-east-2.amazonaws.com/lookaside/static/$(TARGET).tar.gz
 	tar -xzvf $(TARGET).tar.gz
 
 # Include a global make rules file


### PR DESCRIPTION
We want to provide dynamic lookaside files like the beaker blacklist or the kernel fixes file. To that end, move the current files out of the way. This depends on the related deployment MR being merged first.