### PR TITLE
ltp: setup nr_hpage for hugetlb if MemAvailable is low

### DIFF
--- a/distribution/ltp-upstream/lite/Makefile
+++ b/distribution/ltp-upstream/lite/Makefile
@@ -28,7 +28,7 @@ export TEST=$(TOPLEVEL_NAMESPACE)/$(PACKAGE_NAME)/$(RELATIVE_PATH)
 .PHONY: all install download clean
 
 # data files, .c files, scripts anything needed to either compile the test and/or run it.
-FILES=$(METADATA) runtest.sh Makefile PURPOSE
+FILES=$(METADATA) runtest.sh Makefile PURPOSE hugetlb.inc
 
 run: build
 	./runtest.sh

--- a/distribution/ltp-upstream/lite/hugetlb.inc
+++ b/distribution/ltp-upstream/lite/hugetlb.inc
@@ -1,0 +1,27 @@
+hugemmap01 hugemmap01 -s #nr_hpage#
+hugemmap02 hugemmap02 -s #nr_hpage#
+hugemmap04 hugemmap04 -s #nr_hpage#
+
+hugemmap05 hugemmap05 -a #size#
+hugemmap05_m hugemmap05 -m -a #size#
+hugemmap05_s hugemmap05 -s -a #size#
+hugemmap05_ms hugemmap05 -m -s -a #size#
+
+hugemmap06 hugemmap06
+
+hugeshmat01 hugeshmat01 -s #nr_hpage# -i 5
+hugeshmat02 hugeshmat02 -s #nr_hpage# -i 5
+hugeshmat03 hugeshmat03 -s #nr_hpage# -i 5
+hugeshmat04 hugeshmat04 -i 5
+hugeshmat05 hugeshmat05 -i 5
+
+hugeshmctl01 hugeshmctl01 -s #nr_hpage# -i 5
+hugeshmctl02 hugeshmctl02 -s #nr_hpage# -i 5
+hugeshmctl03 hugeshmctl03 -s #nr_hpage# -i 5
+
+hugeshmdt01 hugeshmdt01 -s #nr_hpage# -i 5
+
+hugeshmget01 hugeshmget01 -s #nr_hpage# -i 10
+hugeshmget02 hugeshmget02 -s #nr_hpage# -i 10
+hugeshmget03 hugeshmget03 -s #nr_hpage# -i 10
+hugeshmget05 hugeshmget05 -s #nr_hpage# -i 10


### PR DESCRIPTION
This is mainly for getting rid of errors like:
  mem.c:822: BROK: nr_hugepages = 415, but expect 512

And also involves 'mem_low_mode' to avoid reporting false-positive(like memleak causes above error).

Signed-off-by: Li Wang <liwang@redhat.com>