### PR TITLE
FASTMOVING-1161 ltp ksm failure

### DIFF
--- a/distribution/ltp-upstream/include/knownissue.sh
+++ b/distribution/ltp-upstream/include/knownissue.sh
@@ -128,7 +128,8 @@ function knownissue_filter()
 	# Issue TBD
 	tskip "madvise09" fatal
 	# https://github.com/linux-test-project/ltp/issues/611
-	tskip "ksm0.*" fatal
+	tskip "ksm03.*" fatal
+	tskip "ksm04.*" fatal
 	# Bug 1660161 - [RHEL8] ltp/generic commands mkswap01 fails to create by-UUID device node in aarch64
 	# hugetlb failures should be ignored since that lack of system memory for testing
 	tskip "huge.*" fatal


### PR DESCRIPTION
The failed test cases (`ksm03, ksm03_1, ksm04 and ksm04_01`) are due to https://github.com/linux-test-project/ltp/issues/611. 