### PR TITLE
ltp/knownissue: enable hugetlb test in CKI-ltp

### DIFF
--- a/distribution/ltp-upstream/include/knownissue.sh
+++ b/distribution/ltp-upstream/include/knownissue.sh
@@ -130,8 +130,6 @@ function knownissue_filter()
 	# https://github.com/linux-test-project/ltp/issues/611
 	tskip "ksm0.*" fatal
 	# Bug 1660161 - [RHEL8] ltp/generic commands mkswap01 fails to create by-UUID device node in aarch64
-	# hugetlb failures should be ignored since that lack of system memory for testing
-	tskip "huge.*" fatal
 	# Issue TBD
 	tskip "memfd_create03" unfix
 	# this case always make the beaker task abort with 'incrementing stop' msg

--- a/distribution/ltp-upstream/lite/Makefile
+++ b/distribution/ltp-upstream/lite/Makefile
@@ -1,17 +1,5 @@
-# Copyright (c) 2011 Red Hat, Inc. All rights reserved. This copyrighted material 
-# is made available to anyone wishing to use, modify, copy, or
-# redistribute it subject to the terms and conditions of the GNU General
-# Public License v.2.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# Author: Zhouping Liu <zliu@redhat.com> 
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2020 Red Hat, Inc.
 
 TOPLEVEL_NAMESPACE=/kernel
 PACKAGE_NAME=distribution/ltp
@@ -48,8 +36,7 @@ METADATA=testinfo.desc
 # Generate the testinfo.desc here:
 $(METADATA): Makefile
 	@touch $(METADATA)
-# Change to the test owner's name
-	@echo "Owner:        Zhouping Liu <zliu@redhat.com>" > $(METADATA) # FIXME: customize this
+	@echo "Owner:        Red Hat MM-QE <mm-qe@redhat.com>" > $(METADATA)
 	@echo "Name:         $(TEST)" >> $(METADATA)
 	@echo "Path:         $(TEST_DIR)"	>> $(METADATA)
 	@echo "License:      GPLv2" >> $(METADATA)
@@ -69,7 +56,7 @@ $(METADATA): Makefile
 	@echo "repoRequires: distribution/ltp-upstream/include" >> $(METADATA)
 	@echo "repoRequires: cki_lib" >> $(METADATA)
 	@echo "Environment:  AVC_ERROR=+no_avc_check" >> $(METADATA)
-	@echo "Releases:     RHELServer5 RHEL6 RHEL7" >> $(METADATA)
+	@echo "Releases:     RHELServer5 RHEL6 RHEL7 RHEL8" >> $(METADATA)
 	@echo "Destructive:  no" >> $(METADATA)
 	@echo "Confidential: no" >> $(METADATA)
 	@echo "Priority:     Normal" >>$(METADATA)

--- a/distribution/ltp-upstream/lite/runtest.sh
+++ b/distribution/ltp-upstream/lite/runtest.sh
@@ -140,6 +140,28 @@ function hugetlb_test_pre()
 	[ $low_mem_mode -eq 1 ] && hugetlb_nr_setup
 }
 
+function runtest_tweaker()
+{
+	local runtest="$LTPDIR/runtest/*"
+
+	# tolerate s390 high steal time
+	uname -m | grep -q s390 && {
+		sed -i 's/nanosleep01 nanosleep01/nanosleep01 timeout 300 sh -c "nanosleep01 || true"/' "$runtest"
+		sed -i 's/clock_nanosleep01 clock_nanosleep01/clock_nanosleep01 timeout 300 sh -c "clock_nanosleep01 || true"/' "$runtest"
+		sed -i 's/clock_nanosleep02 clock_nanosleep02/clock_nanosleep02 timeout 300 sh -c "clock_nanosleep02 || true"/' "$runtest"
+		sed -i 's/futex_wait_bitset01 futex_wait_bitset01/futex_wait_bitset01 timeout 30 sh -c "futex_wait_bitset01 || true"/' "$runtest"
+		sed -i 's/futex_wait05 futex_wait05/futex_wait05 timeout 30 sh -c "futex_wait05 || true"/' "$runtest"
+		sed -i 's/epoll_pwait01 epoll_pwait01/epoll_pwait01 timeout 30 sh -c "epoll_pwait01 || true"/' "$runtest"
+		sed -i 's/poll02 poll02/poll02 timeout 30 sh -c "poll02 || true"/' "$runtest"
+		sed -i 's/pselect01 pselect01/pselect01 timeout 30 sh -c "pselect01 || true"/' "$runtest"
+		sed -i 's/pselect01_64 pselect01_64/pselect01_64 timeout 30 sh -c "pselect01_64 || true"/' "$runtest"
+		sed -i 's/select04 select04/select04 timeout 30 sh -c "select04 || true"/' "$runtest"
+	}
+
+	# reduce fork13 iteration
+	sed -i 's/fork13 fork13 -i 1000000/fork13 fork13 -i 10000/' "$runtest"
+}
+
 function knownissue_handle()
 {
 	case $SKIP_LEVEL in
@@ -201,6 +223,7 @@ function ltp_test_pre()
 	fi
 
 	hugetlb_test_pre
+	runtest_tweaker
 	knownissue_handle
 }
 


### PR DESCRIPTION
This shortage memory issue has been solved by:
  commit afe63f3500c1 (ltp: setup nr_hpage for hugetlb if MemAvailable is low)

So let's move hugetlb tests out of the blacklist.

Signed-off-by: Li Wang <liwang@redhat.com>