### PR TITLE
Refactor san-device-stress-test

### DIFF
--- a/storage/hba/san-device-stress/Makefile
+++ b/storage/hba/san-device-stress/Makefile
@@ -58,13 +58,5 @@ $(METADATA): Makefile
 	@echo "Description:     This test will generate I/O using FIO at the device level." >> $(METADATA)
 	@echo "License:		GPL v3" >> $(METADATA)
 	@echo "RunFor:		$(PACKAGE_NAME)" >> $(METADATA)
-	@echo "Requires:        python2-lxml" >> $(METADATA)
-	@echo "Requires:        python3-lxml" >> $(METADATA)
-	@echo "Requires:        fio" >> $(METADATA)
-	@echo "Requires:        libaio-devel" >> $(METADATA)
-	@echo "Requires:        zlib-devel" >> $(METADATA)
-	@echo "Requires:        gcc" >> $(METADATA)
-	@echo "Requires:        git" >> $(METADATA)
-	@echo "RhtsRequires:	hba" >> $(METADATA)
 	@echo "repoRequires:    cki_lib" >> $(METADATA)
 


### PR DESCRIPTION
- Remove extraneous lines from Makefile
- refactor main.sh  - simplify install_fio function as it is not necessary to install from source
- change FIO tests to use libaio and also perform data verification
- simplify the code to find non-boot disks suitible for generating I/O