### PR TITLE
Remove invalid line from Makefile

### DIFF
--- a/storage/hw_raid/Makefile
+++ b/storage/hw_raid/Makefile
@@ -66,4 +66,3 @@ $(METADATA): Makefile
 	@echo "RunFor:		$(PACKAGE_NAME)" >> $(METADATA)
 	@echo "Requires:	$(PACKAGE_NAME)" >> $(METADATA)
 	@echo "repoRequires:    cki_lib" >> $(METADATA)
-	@echo "RhtsRequires:	hw_raid" >> $(METADATA)


### PR DESCRIPTION
-unnecessary to require hw_raid in Makefile as it is a circular dependency