### PR TITLE
Tracepoints: skip iocost_ioc_vrate_adj probe

### DIFF
--- a/tracepoints/operational/runtest.sh
+++ b/tracepoints/operational/runtest.sh
@@ -82,6 +82,13 @@ function testList ()
                 continue
         fi
 
+        echo "$i" | grep -q "iocost_ioc_vrate_adj"
+        if [ $? -eq 0 ]; then
+                echo "Skipping probe $i due to Bug 1824812" | tee -a $OUTPUTFILE
+                echo "Bug 1824812 - Tracepoints: operational test: kernel.trace("iocost:iocost_ioc_vrate_adj") compilation failure" | tee -a $OUTPUTFILE
+                continue
+        fi
+
         echo "$i" | tr -d '\"' >> $PROBES_NAME_FILE
         echo 'probe kernel.trace('$i') { if (pid() == 0) printf("probe hit\n"); }' >> $PROBES_FILE
 


### PR DESCRIPTION
Known issue where iocost:iocost_ioc_vrate_adj fails to compile for Tracepoints test, skip this test for now until BZ 1824812 is resolved.