### PR TITLE
Add libkcapi test for the AF_ALG interface

### DIFF
--- a/packages/libkcapi/af_alg-test/README.md
+++ b/packages/libkcapi/af_alg-test/README.md
@@ -1,0 +1,18 @@
+# Libkcapi AF_ALG test
+
+Libkcapi test that exercises the AF_ALG interface and kernel Crypto API.
+
+Test maintainer: [Ondrej Mosnacek](mailto:omosnace@redhat.com)
+
+## How to run it
+Please refer to the top-level README.md for common dependencies.
+
+### Install dependencies
+```bash
+dnf install -y $(grep '^dependencies=' metadata | cut -f 2 -d = | tr ';' ' ')
+```
+
+### Execute the test
+```bash
+bash ./runtest.sh
+```

--- a/packages/libkcapi/af_alg-test/metadata
+++ b/packages/libkcapi/af_alg-test/metadata
@@ -1,0 +1,11 @@
+[General]
+name=libkcapi-af_alg-test
+owner=Ondrej Mosnacek <omosnace@redhat.com>
+description=Libkcapi test that exercises the AF_ALG interface and kernel Crypto API
+license=GPLv2
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=bash ./runtest.sh
+dependencies=git;coreutils;perl;openssl;gcc;kernel-headers;autoconf;automake;libtool

--- a/packages/libkcapi/af_alg-test/runtest.sh
+++ b/packages/libkcapi/af_alg-test/runtest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2020 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+
+GIT_URL="https://github.com/smuellerDD/libkcapi"
+GIT_REF="v1.1.5"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "git clone '$GIT_URL' libkcapi"
+        rlRun "(cd libkcapi && git checkout $GIT_REF)"
+        rlRun "(cd libkcapi && autoreconf -i)"
+        rlRun "(cd libkcapi && ./configure)"
+        rlRun "make -C libkcapi -j$(nproc)"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "sed -i 's/^exec_test$/exec_test; exit \$?/' libkcapi/test/test-invocation.sh" 0 \
+            "Skip the compilation and 32-bit tests"
+        # NOTE: we could enable the fuzz tests with ENABLE_FUZZ_TEST=1, but
+        # they take a veeeery long time to run and so far I haven't seen
+        # them actually uncover a bug... Let's just keep them off for now.
+        rlRun "./libkcapi/test/test-invocation.sh"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf libkcapi"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
This new test uses the libkcapi's upstream testsuite to test the AF_ALG
socket interface, which provides access to the kernel's Crypto API to
userspace. It is primarily intended to test libkcapi itself, but it has
proven invaluable in discovering kernel bugs as well.

NOTE: The test is currently failing on kernels 5.5+ due to a known issue:
https://lore.kernel.org/linux-crypto/CAAUqJDvZt7_j+eor1sXRg+QmrdXTjMiymFnji86PoatsYPUugA@mail.gmail.com/T/