### PR TITLE
audit-testsuite: run tests as unconfined_t

### DIFF
--- a/packages/audit/audit-testsuite/runtest.sh
+++ b/packages/audit/audit-testsuite/runtest.sh
@@ -158,6 +158,7 @@ rlJournalStart
         for attempt in 1 2 3; do
             TESTS="$TESTS" \
                 unbuffer \
+                runcon unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 \
                 make -seC tests/ test >>results.log 2>&1
             result_rc=$?
 


### PR DESCRIPTION
This should work around a bug in the testsuite (to be fixed by [1]) that
makes it fail when run as system_u:system_r:unconfined_service_t:s0,
which is what the new restraint runs it with now.

[1] https://github.com/linux-audit/audit-testsuite/pull/96

Cc: @The-Mule