### PR TITLE
update legacy rhts-sync- to rstrnt-sync-

### DIFF
--- a/autofs/connectathon/runtest.sh
+++ b/autofs/connectathon/runtest.sh
@@ -123,7 +123,7 @@ cthon_setup() {
 client() {
     rlPhaseStartSetup do-$role-Setup-Client
 	rlFileBackup /etc/sysconfig/{autofs,nfs} /etc/exports /etc/auto.master
-	rlRun 'rhts-sync-block -s SERVER_READY $Server1 $Server2'
+	rlRun 'rstrnt-sync-block -s SERVER_READY $Server1 $Server2'
 	rlRun 'mkdir -p /export/'
 	rlRun 'echo "/export/   *(rw,no_root_squash)" >> /etc/exports'
 	rlRun "systemctl restart nfs-server" "0-255"
@@ -156,7 +156,7 @@ client() {
 				"test.net" | "test.net1")
 				rlRun "./$test $Server1 $Server2" "0,2" "Running $test with $Server1, and $Server2"
 				if [ $? -eq 2 ]; then
-					rlRun 'rhts-sync-set -s DONE${TEST}'
+					rlRun 'rstrnt-sync-set -s DONE${TEST}'
 					rlFileRestore
 					cki_abort_task "Failed to configure $test environment with <$Server1>, and '<$Server2>"
 				fi
@@ -164,7 +164,7 @@ client() {
 			*)#default
 				rlRun "./$test" "0,2" "Running $test"
 				if [ $? -eq 2 ]; then
-					rlRun 'rhts-sync-set -s DONE${TEST}'
+					rlRun 'rstrnt-sync-set -s DONE${TEST}'
 					rlFileRestore
 					cki_abort_task "Failed to configure $test environment"
 				fi
@@ -176,7 +176,7 @@ client() {
 
 	rlPhaseStartCleanup do-$role-Cleanup-
 		rlRun 'popd'
-		rlRun 'rhts-sync-set -s DONE${TEST}'
+		rlRun 'rstrnt-sync-set -s DONE${TEST}'
 		rlFileRestore
 	rlPhaseEnd
 }
@@ -207,12 +207,12 @@ server() {
 	if [ $? -ne 0 ]; then
 		cki_abort_task "Failed to restart server nfs server"
 	fi
-	rlRun "rhts-sync-set -s SERVER_READY"
+	rlRun "rstrnt-sync-set -s SERVER_READY"
     rlPhaseEnd
 
     rlPhaseStartCleanup do-$role-Cleanup-
 	rlLog "{INFO} server ready. wait the client ..."
-	rlRun 'rhts-sync-block -s DONE${TEST} $Client'
+	rlRun 'rstrnt-sync-block -s DONE${TEST} $Client'
 	rlFileRestore
     rlPhaseEnd
 }

--- a/networking/common/include.sh
+++ b/networking/common/include.sh
@@ -223,15 +223,15 @@ net_sync()
 	fi
 	log "Start sync ${FLAG}"
 	if $(echo $SERVERS | grep -q -i $HOSTNAME);then
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 		for client in $CLIENTS; do
-			rhts-sync-block -s ${FLAG} $client
+			rstrnt-sync-block -s ${FLAG} $client
 		done
 	elif $(echo $CLIENTS | grep -q -i $HOSTNAME);then
 		for server in $SERVERS; do
-			rhts-sync-block -s ${FLAG} $server
+			rstrnt-sync-block -s ${FLAG} $server
 		done
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 	fi
 	log "Finish sync ${FLAG}"
 }
@@ -328,9 +328,9 @@ fi
 
 popd > /dev/null
 
-# use our own rhts-sync for manually testing
+# use our own rstrnt-sync for manually testing
 if [ ! "$JOBID" ];then
-rhts-sync-set()
+rstrnt-sync-set()
 {
 	local message=$2
 	local timeout=3600
@@ -349,11 +349,11 @@ rhts-sync-set()
 		sleep 5
 		let timeout=timeout-5
 	done
-	if [ $timeout -le 0 ]; then test_warn "rhts-sync-set $HOSTNAME $message failed"; fi
-	echo "rhts-sync-set -s $message DONE"
+	if [ $timeout -le 0 ]; then test_warn "rstrnt-sync-set $HOSTNAME $message failed"; fi
+	echo "rstrnt-sync-set -s $message DONE"
 }
 
-rhts-sync-block()
+rstrnt-sync-block()
 {
 	local message=$2
 	local i
@@ -370,6 +370,6 @@ rhts-sync-block()
 			sleep 5
 		done
 	done
-	echo "rhts-sync-block -s $message $@ DONE"
+	echo "rstrnt-sync-block -s $message $@ DONE"
 }
 fi

--- a/networking/route/pmtu/common/include.sh
+++ b/networking/route/pmtu/common/include.sh
@@ -199,15 +199,15 @@ net_sync()
 	[ ! "$DONT_GET_ROUND" ] && FLAG="$(get_round)_${FLAG}"
 	log "Start sync ${FLAG}"
 	if $(echo $SERVERS | grep -q -i $HOSTNAME);then
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 		for client in $CLIENTS; do
-			rhts-sync-block -s ${FLAG} $client
+			rstrnt-sync-block -s ${FLAG} $client
 		done
 	elif $(echo $CLIENTS | grep -q -i $HOSTNAME);then
 		for server in $SERVERS; do
-			rhts-sync-block -s ${FLAG} $server
+			rstrnt-sync-block -s ${FLAG} $server
 		done
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 	fi
 	log "Finish sync ${FLAG}"
 }
@@ -315,10 +315,10 @@ fi
 
 popd > /dev/null
 
-# use our own rhts-sync for manually testing
+# use our own rstrnt-sync for manually testing
 if [ ! "$JOBID" ];then
 ssh_key_install
-rhts-sync-set()
+rstrnt-sync-set()
 {
 	local message=$2
 	local timeout=3600
@@ -338,13 +338,13 @@ rhts-sync-set()
 		let timeout=timeout-5
 	done
 	if [ $timeout -le 0 ]; then
-		test_warn "rhts-sync-set $HOSTNAME $message failed"
+		test_warn "rstrnt-sync-set $HOSTNAME $message failed"
 		rstrnt-abort -t recipe
 	fi
-	echo "rhts-sync-set -s $message DONE"
+	echo "rstrnt-sync-set -s $message DONE"
 }
 
-rhts-sync-block()
+rstrnt-sync-block()
 {
 	local message=$2
 	local i
@@ -361,6 +361,6 @@ rhts-sync-block()
 			sleep 5
 		done
 	done
-	echo "rhts-sync-block -s $message $@ DONE"
+	echo "rstrnt-sync-block -s $message $@ DONE"
 }
 fi

--- a/networking/route/route_func/common/include.sh
+++ b/networking/route/route_func/common/include.sh
@@ -224,15 +224,15 @@ net_sync()
 	fi
 	log "Start sync ${FLAG}"
 	if $(echo $SERVERS | grep -q -i $HOSTNAME);then
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 		for client in $CLIENTS; do
-			rhts-sync-block -s ${FLAG} $client
+			rstrnt-sync-block -s ${FLAG} $client
 		done
 	elif $(echo $CLIENTS | grep -q -i $HOSTNAME);then
 		for server in $SERVERS; do
-			rhts-sync-block -s ${FLAG} $server
+			rstrnt-sync-block -s ${FLAG} $server
 		done
-		rhts-sync-set -s ${FLAG}
+		rstrnt-sync-set -s ${FLAG}
 	fi
 	log "Finish sync ${FLAG}"
 }
@@ -343,10 +343,10 @@ fi
 
 popd > /dev/null
 
-# use our own rhts-sync for manually testing
+# use our own rstrnt-sync for manually testing
 if [ ! "$JOBID" ];then
 ssh_key_install
-rhts-sync-set()
+rstrnt-sync-set()
 {
 	local message=$2
 	local timeout=3600
@@ -365,11 +365,11 @@ rhts-sync-set()
 		sleep 5
 		let timeout=timeout-5
 	done
-	if [ $timeout -le 0 ]; then test_warn "rhts-sync-set $HOSTNAME $message failed"; fi
-	echo "rhts-sync-set -s $message DONE"
+	if [ $timeout -le 0 ]; then test_warn "rstrnt-sync-set $HOSTNAME $message failed"; fi
+	echo "rstrnt-sync-set -s $message DONE"
 }
 
-rhts-sync-block()
+rstrnt-sync-block()
 {
 	local message=$2
 	local i
@@ -386,6 +386,6 @@ rhts-sync-block()
 			sleep 5
 		done
 	done
-	echo "rhts-sync-block -s $message $@ DONE"
+	echo "rstrnt-sync-block -s $message $@ DONE"
 }
 fi

--- a/networking/tunnel/geneve/basic/runtest.sh
+++ b/networking/tunnel/geneve/basic/runtest.sh
@@ -77,7 +77,7 @@ then
 		rlRun "ip route add $gre_c_ip4net dev $gre_devname"
 		rlRun "ip -6 route add $gre_c_ip6net dev $gre_devname"
 
-		rhts-sync-block -s CLIENT_GRE_CONFIG_$version $CLIENTS
+		rstrnt-sync-block -s CLIENT_GRE_CONFIG_$version $CLIENTS
 		rlRun "tcpdump -i any -w grev4.pcap &"
 		rlRun "sleep 5"
 		rlRun "ping $gre_c_ip4 -c 5"
@@ -109,22 +109,22 @@ then
 			[ $? -ne 0 ] && rlRun -l "tcpdump -r grev6.pcap -nnle"
 		fi
 
-		rhts-sync-block -s CLIENT_IPERF_TCPV4_$version $CLIENTS
+		rstrnt-sync-block -s CLIENT_IPERF_TCPV4_$version $CLIENTS
 		rlRun "iperf -c $gre_c_ip4"
-		rhts-sync-set -s SERVER_IPERF_TCPV4_FINISH_$version
-		rhts-sync-block -s CLIENT_IPERF_UDPV4_$version $CLIENTS
+		rstrnt-sync-set -s SERVER_IPERF_TCPV4_FINISH_$version
+		rstrnt-sync-block -s CLIENT_IPERF_UDPV4_$version $CLIENTS
 		rlRun "iperf -u -c $gre_c_ip4"
-		rhts-sync-set -s SERVER_IPERF_UDPV4_FINISH_$version
+		rstrnt-sync-set -s SERVER_IPERF_UDPV4_FINISH_$version
 
-		rhts-sync-block -s CLIENT_IPERF_TCPV6_$version $CLIENTS
+		rstrnt-sync-block -s CLIENT_IPERF_TCPV6_$version $CLIENTS
 		rlRun "iperf -V -c $gre_c_ip6"
-		rhts-sync-set -s SERVER_IPERF_TCPV6_FINISH_$version
-		rhts-sync-block -s CLIENT_IPERF_UDPV6_$version $CLIENTS
+		rstrnt-sync-set -s SERVER_IPERF_TCPV6_FINISH_$version
+		rstrnt-sync-block -s CLIENT_IPERF_UDPV6_$version $CLIENTS
 		rlRun "iperf -u -V -c $gre_c_ip6"
 
 		rlRun "netperf -L $gre_s_ip4 -H $gre_c_ip4 -t UDP_STREAM"
 		rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t UDP_STREAM"
-		rhts-sync-set -s SERVER_ALL_FINISH_$version
+		rstrnt-sync-set -s SERVER_ALL_FINISH_$version
 		rlRun "ip -d -s link sh $gre_devname"
 		rlRun "ip link del $gre_devname"
 		rlRun "ip link del $gre_devname" "0-255"
@@ -153,24 +153,24 @@ then
 		rlRun "pkill -9 netserver" "0-255"
 		rlRun "netserver -d"
 
-		rhts-sync-set -s CLIENT_GRE_CONFIG_$version
+		rstrnt-sync-set -s CLIENT_GRE_CONFIG_$version
 		rlRun "pkill -9 iperf" "0-255"
 		rlRun "iperf -s -B $gre_c_ip4 -D &"
-		rhts-sync-set -s CLIENT_IPERF_TCPV4_$version
-		rhts-sync-block -s SERVER_IPERF_TCPV4_FINISH_$version $SERVERS
+		rstrnt-sync-set -s CLIENT_IPERF_TCPV4_$version
+		rstrnt-sync-block -s SERVER_IPERF_TCPV4_FINISH_$version $SERVERS
 		rlRun "pkill -9 iperf" "0-255"
 		rlRun "iperf -s -u -B $gre_c_ip4 -D &"
-		rhts-sync-set -s CLIENT_IPERF_UDPV4_$version
+		rstrnt-sync-set -s CLIENT_IPERF_UDPV4_$version
 
-		rhts-sync-block -s SERVER_IPERF_UDPV4_FINISH_$version $SERVERS
+		rstrnt-sync-block -s SERVER_IPERF_UDPV4_FINISH_$version $SERVERS
 		rlRun "pkill -9 iperf" "0-255"
 		rlRun "iperf -s -V -B $gre_c_ip6 -D &"
-		rhts-sync-set -s CLIENT_IPERF_TCPV6_$version
-		rhts-sync-block -s SERVER_IPERF_TCPV6_FINISH_$version $SERVERS
+		rstrnt-sync-set -s CLIENT_IPERF_TCPV6_$version
+		rstrnt-sync-block -s SERVER_IPERF_TCPV6_FINISH_$version $SERVERS
 		rlRun "pkill -9 iperf" "0-255"
 		rlRun "iperf -s -u -V -B $gre_c_ip6 -D &"
-		rhts-sync-set -s CLIENT_IPERF_UDPV6_$version
-		rhts-sync-block -s SERVER_ALL_FINISH_$version $SERVERS
+		rstrnt-sync-set -s CLIENT_IPERF_UDPV6_$version
+		rstrnt-sync-block -s SERVER_ALL_FINISH_$version $SERVERS
 		rlRun "ip -d -s link sh $gre_devname"
 
 		rlRun "pkill -9 iperf"

--- a/networking/tunnel/gre/basic/runtest.sh
+++ b/networking/tunnel/gre/basic/runtest.sh
@@ -65,17 +65,17 @@ then
 
 	rlRun "killall -9 socat" "0-255"
 	rlRun "socat tcp4-listen:51110 - > server4.log &"
-	rhts-sync-set -s SERVER_SOCAT_TCP4_READY
-	rhts-sync-block -s CLIENT_NC_TCP4_FINISH $CLIENTS
+	rstrnt-sync-set -s SERVER_SOCAT_TCP4_READY
+	rstrnt-sync-block -s CLIENT_NC_TCP4_FINISH $CLIENTS
 	rlAssertGrep "h" server4.log
 
 	rlRun "killall -9 socat" "0-255"
 	rlRun "socat tcp6-listen:51111 - > server6.log &"
-	rhts-sync-set -s SERVER_SOCAT_TCP6_READY
-	rhts-sync-block -s CLIENT_NC_TCP6_FINISH $CLIENTS
+	rstrnt-sync-set -s SERVER_SOCAT_TCP6_READY
+	rstrnt-sync-block -s CLIENT_NC_TCP6_FINISH $CLIENTS
 	rlAssertGrep "h" server6.log
 
-	rhts-sync-block -s CLIENT_GRE_CONFIG $CLIENTS
+	rstrnt-sync-block -s CLIENT_GRE_CONFIG $CLIENTS
 	rlRun "tcpdump -i any -w grev4.pcap &"
 	rlRun "sleep 5"
 	rlRun "ping $gre_c_ip4 -c 5"
@@ -93,22 +93,22 @@ then
 	rlRun "tcpdump -r grev6.pcap -nnle | grep \"$SER_ADDR4 > $CLI_ADDR4: GREv0, proto IPv6 (0x86dd).*: $gre_s_ip6 > $gre_c_ip6\""
 	[ $? -ne 0 ] && rlRun -l "tcpdump -r grev6.pcap -nnle"
 
-	rhts-sync-block -s CLIENT_IPERF_TCPV4 $CLIENTS
+	rstrnt-sync-block -s CLIENT_IPERF_TCPV4 $CLIENTS
 	rlRun "iperf -c $gre_c_ip4"
-	rhts-sync-set -s SERVER_IPERF_TCPV4_FINISH
-	rhts-sync-block -s CLIENT_IPERF_UDPV4 $CLIENTS
+	rstrnt-sync-set -s SERVER_IPERF_TCPV4_FINISH
+	rstrnt-sync-block -s CLIENT_IPERF_UDPV4 $CLIENTS
 	rlRun "iperf -u -c $gre_c_ip4"
-	rhts-sync-set -s SERVER_IPERF_UDPV4_FINISH
+	rstrnt-sync-set -s SERVER_IPERF_UDPV4_FINISH
 
-	rhts-sync-block -s CLIENT_IPERF_TCPV6 $CLIENTS
+	rstrnt-sync-block -s CLIENT_IPERF_TCPV6 $CLIENTS
 	rlRun "iperf -V -c $gre_c_ip6"
-	rhts-sync-set -s SERVER_IPERF_TCPV6_FINISH
-	rhts-sync-block -s CLIENT_IPERF_UDPV6 $CLIENTS
+	rstrnt-sync-set -s SERVER_IPERF_TCPV6_FINISH
+	rstrnt-sync-block -s CLIENT_IPERF_UDPV6 $CLIENTS
 	rlRun "iperf -u -V -c $gre_c_ip6"
 
 	rlRun "netperf -L $gre_s_ip4 -H $gre_c_ip4 -t UDP_STREAM"
 	rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t UDP_STREAM"
-	rhts-sync-set -s SERVER_ALL_FINISH
+	rstrnt-sync-set -s SERVER_ALL_FINISH
 	rlRun "ip -d -s tunnel show $gre_devname"
 	rlRun "ip -d -s link sh $gre_devname"
 	rlRun "ip link del $gre_devname"
@@ -130,31 +130,31 @@ then
 	rlRun "pkill -9 netserver" "0-255"
 	rlRun "netserver -d"
 
-	rhts-sync-block -s SERVER_SOCAT_TCP4_READY $SERVERS
+	rstrnt-sync-block -s SERVER_SOCAT_TCP4_READY $SERVERS
 	rlRun "nc -4 $gre_s_ip4 51110 <<< h"
-	rhts-sync-set -s CLIENT_NC_TCP4_FINISH
-	rhts-sync-block -s SERVER_SOCAT_TCP6_READY $SERVERS
+	rstrnt-sync-set -s CLIENT_NC_TCP4_FINISH
+	rstrnt-sync-block -s SERVER_SOCAT_TCP6_READY $SERVERS
 	rlRun "nc -6 $gre_s_ip6 51111 <<< h"
-	rhts-sync-set -s CLIENT_NC_TCP6_FINISH
+	rstrnt-sync-set -s CLIENT_NC_TCP6_FINISH
 
-	rhts-sync-set -s CLIENT_GRE_CONFIG
+	rstrnt-sync-set -s CLIENT_GRE_CONFIG
 	rlRun "pkill -9 iperf" "0-255"
 	rlRun "iperf -s -B $gre_c_ip4 -D &"
-	rhts-sync-set -s CLIENT_IPERF_TCPV4
-	rhts-sync-block -s SERVER_IPERF_TCPV4_FINISH $SERVERS
+	rstrnt-sync-set -s CLIENT_IPERF_TCPV4
+	rstrnt-sync-block -s SERVER_IPERF_TCPV4_FINISH $SERVERS
 	rlRun "pkill -9 iperf" "0-255"
 	rlRun "iperf -s -u -B $gre_c_ip4 -D &"
-	rhts-sync-set -s CLIENT_IPERF_UDPV4
+	rstrnt-sync-set -s CLIENT_IPERF_UDPV4
 
-	rhts-sync-block -s SERVER_IPERF_UDPV4_FINISH $SERVERS
+	rstrnt-sync-block -s SERVER_IPERF_UDPV4_FINISH $SERVERS
 	rlRun "pkill -9 iperf" "0-255"
 	rlRun "iperf -s -V -B $gre_c_ip6 -D &"
-	rhts-sync-set -s CLIENT_IPERF_TCPV6
-	rhts-sync-block -s SERVER_IPERF_TCPV6_FINISH $SERVERS
+	rstrnt-sync-set -s CLIENT_IPERF_TCPV6
+	rstrnt-sync-block -s SERVER_IPERF_TCPV6_FINISH $SERVERS
 	rlRun "pkill -9 iperf" "0-255"
 	rlRun "iperf -s -u -V -B $gre_c_ip6 -D &"
-	rhts-sync-set -s CLIENT_IPERF_UDPV6
-	rhts-sync-block -s SERVER_ALL_FINISH $SERVERS
+	rstrnt-sync-set -s CLIENT_IPERF_UDPV6
+	rstrnt-sync-block -s SERVER_ALL_FINISH $SERVERS
 	rlRun "ip -d -s link sh $gre_devname"
 	rlRun "ip -d -s tunnel show $gre_devname"
 

--- a/networking/tunnel/l2tp/basic/runtest.sh
+++ b/networking/tunnel/l2tp/basic/runtest.sh
@@ -72,21 +72,21 @@ then
 			rlRun "ip -6 addr add $gre_s_ip6/64 dev $gre_devname"
 			rlRun "ip route add $gre_c_ip4net dev $gre_devname"
 			rlRun "ip -6 route add $gre_c_ip6net dev $gre_devname"
-			rhts-sync-block -s CLIENT_GRE_CONFIG_${encap_type}_$ipversion $CLIENTS
+			rstrnt-sync-block -s CLIENT_GRE_CONFIG_${encap_type}_$ipversion $CLIENTS
 			rlRun "ping $gre_c_ip4 -c 5"
 			rlRun "ping6 $gre_c_ip6 -c 5"
 
-			rhts-sync-block -s CLIENT_IPERF_TCPV4_${encap_type}_$ipversion $CLIENTS
+			rstrnt-sync-block -s CLIENT_IPERF_TCPV4_${encap_type}_$ipversion $CLIENTS
 			rlRun "iperf -c $gre_c_ip4"
-			rhts-sync-set -s SERVER_IPERF_TCPV4_FINISH_${encap_type}_$ipversion
-			rhts-sync-block -s CLIENT_IPERF_UDPV4_${encap_type}_$ipversion $CLIENTS
+			rstrnt-sync-set -s SERVER_IPERF_TCPV4_FINISH_${encap_type}_$ipversion
+			rstrnt-sync-block -s CLIENT_IPERF_UDPV4_${encap_type}_$ipversion $CLIENTS
 			rlRun "iperf -u -c $gre_c_ip4"
-			rhts-sync-set -s SERVER_IPERF_UDPV4_FINISH_${encap_type}_$ipversion
+			rstrnt-sync-set -s SERVER_IPERF_UDPV4_FINISH_${encap_type}_$ipversion
 
-			rhts-sync-block -s CLIENT_IPERF_TCPV6_${encap_type}_$ipversion $CLIENTS
+			rstrnt-sync-block -s CLIENT_IPERF_TCPV6_${encap_type}_$ipversion $CLIENTS
 			rlRun "iperf -V -c $gre_c_ip6"
-			rhts-sync-set -s SERVER_IPERF_TCPV6_FINISH_${encap_type}_$ipversion
-			rhts-sync-block -s CLIENT_IPERF_UDPV6_${encap_type}_$ipversion $CLIENTS
+			rstrnt-sync-set -s SERVER_IPERF_TCPV6_FINISH_${encap_type}_$ipversion
+			rstrnt-sync-block -s CLIENT_IPERF_UDPV6_${encap_type}_$ipversion $CLIENTS
 			rlRun "iperf -u -V -c $gre_c_ip6"
 
 			rlRun "netperf -L $gre_s_ip4 -H $gre_c_ip4 -t UDP_STREAM"
@@ -95,7 +95,7 @@ then
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t UDP_STREAM"
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t TCP_STREAM"
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t SCTP_STREAM"
-			rhts-sync-set -s SERVER_ALL_FINISH_${encap_type}_$ipversion
+			rstrnt-sync-set -s SERVER_ALL_FINISH_${encap_type}_$ipversion
 			rlRun "ip -d -s link sh $gre_devname"
 			rlRun "ip l2tp del tunnel tunnel_id 3000 peer_tunnel_id 4000"
 			# can't add tunnel with same tunnel id right after tunnel is deleted
@@ -135,24 +135,24 @@ then
 			rlRun "pkill -9 netserver" "0-255"
 			rlRun "netserver -d"
 
-			rhts-sync-set -s CLIENT_GRE_CONFIG_${encap_type}_$ipversion
+			rstrnt-sync-set -s CLIENT_GRE_CONFIG_${encap_type}_$ipversion
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -B $gre_c_ip4 -D &"
-			rhts-sync-set -s CLIENT_IPERF_TCPV4_${encap_type}_$ipversion
-			rhts-sync-block -s SERVER_IPERF_TCPV4_FINISH_${encap_type}_$ipversion $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_TCPV4_${encap_type}_$ipversion
+			rstrnt-sync-block -s SERVER_IPERF_TCPV4_FINISH_${encap_type}_$ipversion $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -u -B $gre_c_ip4 -D &"
-			rhts-sync-set -s CLIENT_IPERF_UDPV4_${encap_type}_$ipversion
+			rstrnt-sync-set -s CLIENT_IPERF_UDPV4_${encap_type}_$ipversion
 
-			rhts-sync-block -s SERVER_IPERF_UDPV4_FINISH_${encap_type}_$ipversion $SERVERS
+			rstrnt-sync-block -s SERVER_IPERF_UDPV4_FINISH_${encap_type}_$ipversion $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -V -B $gre_c_ip6 -D &"
-			rhts-sync-set -s CLIENT_IPERF_TCPV6_${encap_type}_$ipversion
-			rhts-sync-block -s SERVER_IPERF_TCPV6_FINISH_${encap_type}_$ipversion $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_TCPV6_${encap_type}_$ipversion
+			rstrnt-sync-block -s SERVER_IPERF_TCPV6_FINISH_${encap_type}_$ipversion $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -u -V -B $gre_c_ip6 -D &"
-			rhts-sync-set -s CLIENT_IPERF_UDPV6_${encap_type}_$ipversion
-			rhts-sync-block -s SERVER_ALL_FINISH_${encap_type}_$ipversion $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_UDPV6_${encap_type}_$ipversion
+			rstrnt-sync-block -s SERVER_ALL_FINISH_${encap_type}_$ipversion $SERVERS
 			rlRun "ip -d -s link sh $gre_devname"
 
 			rlRun "pkill -9 iperf"

--- a/networking/tunnel/vxlan/basic/runtest.sh
+++ b/networking/tunnel/vxlan/basic/runtest.sh
@@ -94,7 +94,7 @@ then
 			rlRun "ip route add $gre_c_ip4net dev $gre_devname"
 			rlRun "ip -6 route add $gre_c_ip6net dev $gre_devname"
 
-			rhts-sync-block -s CLIENT_GRE_CONFIG_${ipversion}_$remote $CLIENTS
+			rstrnt-sync-block -s CLIENT_GRE_CONFIG_${ipversion}_$remote $CLIENTS
 			rlRun "tcpdump -i any -w grev4.pcap &"
 			rlRun "sleep 5"
 			rlRun "ping $gre_c_ip4 -c 5"
@@ -133,17 +133,17 @@ then
 				[ $? -ne 0 ] && rlRun -l "tcpdump -r grev6.pcap -nnle"
 			fi
 			fi
-			rhts-sync-block -s CLIENT_IPERF_TCPV4_${ipversion}_$remote $CLIENTS
+			rstrnt-sync-block -s CLIENT_IPERF_TCPV4_${ipversion}_$remote $CLIENTS
 			rlRun "iperf -c $gre_c_ip4"
-			rhts-sync-set -s SERVER_IPERF_TCPV4_FINISH_${ipversion}_$remote
-			rhts-sync-block -s CLIENT_IPERF_UDPV4_${ipversion}_$remote $CLIENTS
+			rstrnt-sync-set -s SERVER_IPERF_TCPV4_FINISH_${ipversion}_$remote
+			rstrnt-sync-block -s CLIENT_IPERF_UDPV4_${ipversion}_$remote $CLIENTS
 			rlRun "iperf -u -c $gre_c_ip4"
-			rhts-sync-set -s SERVER_IPERF_UDPV4_FINISH_${ipversion}_$remote
+			rstrnt-sync-set -s SERVER_IPERF_UDPV4_FINISH_${ipversion}_$remote
 
-			rhts-sync-block -s CLIENT_IPERF_TCPV6_${ipversion}_$remote $CLIENTS
+			rstrnt-sync-block -s CLIENT_IPERF_TCPV6_${ipversion}_$remote $CLIENTS
 			rlRun "iperf -V -c $gre_c_ip6"
-			rhts-sync-set -s SERVER_IPERF_TCPV6_FINISH_${ipversion}_$remote
-			rhts-sync-block -s CLIENT_IPERF_UDPV6_${ipversion}_$remote $CLIENTS
+			rstrnt-sync-set -s SERVER_IPERF_TCPV6_FINISH_${ipversion}_$remote
+			rstrnt-sync-block -s CLIENT_IPERF_UDPV6_${ipversion}_$remote $CLIENTS
 			rlRun "iperf -u -V -c $gre_c_ip6"
 
 			rlRun "netperf -L $gre_s_ip4 -H $gre_c_ip4 -t UDP_STREAM"
@@ -152,7 +152,7 @@ then
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t UDP_STREAM"
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t TCP_STREAM"
 			rlRun "netperf -L $gre_s_ip6 -H $gre_c_ip6 -t SCTP_STREAM -- -m 16k"
-			rhts-sync-set -s SERVER_ALL_FINISH_${ipversion}_$remote
+			rstrnt-sync-set -s SERVER_ALL_FINISH_${ipversion}_$remote
 			rlRun "ip -d -s link sh $gre_devname"
 			rlRun "ip link del $gre_devname"
 
@@ -187,24 +187,24 @@ then
 			rlRun "pkill -9 netserver" "0-255"
 			rlRun "netserver -d"
 
-			rhts-sync-set -s CLIENT_GRE_CONFIG_${ipversion}_$remote
+			rstrnt-sync-set -s CLIENT_GRE_CONFIG_${ipversion}_$remote
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -B $gre_c_ip4 -D &"
-			rhts-sync-set -s CLIENT_IPERF_TCPV4_${ipversion}_$remote
-			rhts-sync-block -s SERVER_IPERF_TCPV4_FINISH_${ipversion}_$remote $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_TCPV4_${ipversion}_$remote
+			rstrnt-sync-block -s SERVER_IPERF_TCPV4_FINISH_${ipversion}_$remote $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -u -B $gre_c_ip4 -D &"
-			rhts-sync-set -s CLIENT_IPERF_UDPV4_${ipversion}_$remote
+			rstrnt-sync-set -s CLIENT_IPERF_UDPV4_${ipversion}_$remote
 
-			rhts-sync-block -s SERVER_IPERF_UDPV4_FINISH_${ipversion}_$remote $SERVERS
+			rstrnt-sync-block -s SERVER_IPERF_UDPV4_FINISH_${ipversion}_$remote $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -V -B $gre_c_ip6 -D &"
-			rhts-sync-set -s CLIENT_IPERF_TCPV6_${ipversion}_$remote
-			rhts-sync-block -s SERVER_IPERF_TCPV6_FINISH_${ipversion}_$remote $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_TCPV6_${ipversion}_$remote
+			rstrnt-sync-block -s SERVER_IPERF_TCPV6_FINISH_${ipversion}_$remote $SERVERS
 			rlRun "pkill -9 iperf" "0-255"
 			rlRun "iperf -s -u -V -B $gre_c_ip6 -D &"
-			rhts-sync-set -s CLIENT_IPERF_UDPV6_${ipversion}_$remote
-			rhts-sync-block -s SERVER_ALL_FINISH_${ipversion}_$remote $SERVERS
+			rstrnt-sync-set -s CLIENT_IPERF_UDPV6_${ipversion}_$remote
+			rstrnt-sync-block -s SERVER_ALL_FINISH_${ipversion}_$remote $SERVERS
 			rlRun "ip -d -s link sh $gre_devname"
 
 			rlRun "pkill -9 iperf"

--- a/networking/vnic/ipvlan/basic/runtest.sh
+++ b/networking/vnic/ipvlan/basic/runtest.sh
@@ -71,7 +71,7 @@ rlPhaseStartTest "multihost_netns"
 		rlRun "ip netns exec ns_s ip route add default dev ipvlan_s"
 		rlRun "ip netns exec ns_s ip -6 route add default dev ipvlan_s"
 
-		rhts-sync-block -s IPVLAN_MULTIHOST_CLIENT_READY $CLIENTS
+		rstrnt-sync-block -s IPVLAN_MULTIHOST_CLIENT_READY $CLIENTS
 		for flag in vepa private bridge
 		do
 			rlLog "mode l2 $flag"
@@ -90,7 +90,7 @@ rlPhaseStartTest "multihost_netns"
 			rlRun "ip netns exec ns_s netperf -6 -H 5010:$netid::172 -t SCTP_STREAM -l 1 -- -m 16k"
 		done
 
-		rhts-sync-set -s IPVLAN_MULTIHOST_MODE2_FINISH
+		rstrnt-sync-set -s IPVLAN_MULTIHOST_MODE2_FINISH
 
 		#rlRun "ip netns exec ns_s ip route add default dev ipvlan_s"
 		#rlRun "ip netns exec ns_s ip -6 route add default dev ipvlan_s"
@@ -101,7 +101,7 @@ rlPhaseStartTest "multihost_netns"
 		do
 			rlRun "ip netns exec ns_s ip link set ipvlan_s type ipvlan mode $mode"
 			rlRun "ip netns exec ns_s ip link set ipvlan_s type ipvlan mode $mode" "0-255"
-			rhts-sync-block -s IPVLAN_MULTIHOST_${mode}_READY $CLIENTS
+			rstrnt-sync-block -s IPVLAN_MULTIHOST_${mode}_READY $CLIENTS
 			for flag in vepa private bridge
 			do
 				rlLog "mode $mode $flag"
@@ -126,7 +126,7 @@ rlPhaseStartTest "multihost_netns"
 					rlRun "ip netns exec ns_s netperf -6 -H 5010:$netid::172 -t SCTP_STREAM -l 1 -- -m 16k"
 				done
 			done
-			rhts-sync-set -s IPVLAN_MULTIHOST_${mode}_FINISH
+			rstrnt-sync-set -s IPVLAN_MULTIHOST_${mode}_FINISH
 
 		done
 
@@ -147,8 +147,8 @@ rlPhaseStartTest "multihost_netns"
 		rlRun "ip route add 192.168.$netid.171 dev $TEST_IFACE"
 		rlRun "ip -6 route add 5010:$netid::171 dev $TEST_IFACE"
 
-		rhts-sync-set -s IPVLAN_MULTIHOST_CLIENT_READY
-		rhts-sync-block -s IPVLAN_MULTIHOST_MODE2_FINISH $SERVERS
+		rstrnt-sync-set -s IPVLAN_MULTIHOST_CLIENT_READY
+		rstrnt-sync-block -s IPVLAN_MULTIHOST_MODE2_FINISH $SERVERS
 		rlRun "ip route del 192.168.$netid.171 dev $TEST_IFACE"
 		rlRun "ip -6 route del 5010:$netid::171 dev $TEST_IFACE"
 
@@ -160,8 +160,8 @@ rlPhaseStartTest "multihost_netns"
 		for mode in l3 l3s
 		do
 			rlRun "ip netns exec ns_c ip link set ipvlan_c type ipvlan mode $mode"
-			rhts-sync-set -s IPVLAN_MULTIHOST_${mode}_READY
-			rhts-sync-block -s IPVLAN_MULTIHOST_${mode}_FINISH $SERVERS
+			rstrnt-sync-set -s IPVLAN_MULTIHOST_${mode}_READY
+			rstrnt-sync-block -s IPVLAN_MULTIHOST_${mode}_FINISH $SERVERS
 		done
 
 		rlRun "ip netns exec ns_c pkill netserver" "0-255"
@@ -648,8 +648,8 @@ then
 		ip netns exec test$i mdump -q -omdump_v4_${i}_10.log -s 224.9.10.10 12970 ipvlan$i &
 	done
 	rlRun "sleep 5"
-	rhts-sync-set -s IPVLAN_BASIC_MULTICAST_SERVER_V4_MDUMP_READY
-	rhts-sync-block -s IPVLAN_BASIC_MULTICAST_CLIENT_V4_MSEND_DONE $CLIENTS
+	rstrnt-sync-set -s IPVLAN_BASIC_MULTICAST_SERVER_V4_MDUMP_READY
+	rstrnt-sync-block -s IPVLAN_BASIC_MULTICAST_CLIENT_V4_MSEND_DONE $CLIENTS
 
 	rlRun "sleep 5"
 	if [ "`grep '0.000000% loss' mdump_v4*_1.log | wc -l`" -ne 100 ]
@@ -755,8 +755,8 @@ then
 		ip netns exec test$i mdump -q -f 6 -omdump_v6_${i}_10.log -s ff0e:1234::10 12970 ipvlan$i &
 	done
 	rlRun "sleep 5"
-	rhts-sync-set -s IPVLAN_BASIC_MULTICAST_SERVER_V6_MDUMP_READY
-	rhts-sync-block -s IPVLAN_BASIC_MULTICAST_CLIENT_V6_MSEND_DONE $CLIENTS
+	rstrnt-sync-set -s IPVLAN_BASIC_MULTICAST_SERVER_V6_MDUMP_READY
+	rstrnt-sync-block -s IPVLAN_BASIC_MULTICAST_CLIENT_V6_MSEND_DONE $CLIENTS
 	rlRun "sleep 5"
 
 	if [ "`grep '0.000000% loss' mdump_v6*_1.log | wc -l`" -ne 100 ]
@@ -832,7 +832,7 @@ then
 		IFACE_NAME=$TEST_IFACE
 		rlRun "dhclient -v $IFACE_NAME"
 	fi
-	rhts-sync-block -s IPVLAN_BASIC_MULTICAST_SERVER_V4_MDUMP_READY $SERVERS
+	rstrnt-sync-block -s IPVLAN_BASIC_MULTICAST_SERVER_V4_MDUMP_READY $SERVERS
 	rlRun "sleep 5"
 
 	port_num=12960
@@ -841,8 +841,8 @@ then
 		let port_num++
 		rlRun "msend -qq -1 224.9.10.$i $port_num 15 $IFACE_NAME"
 	done
-	rhts-sync-set -s IPVLAN_BASIC_MULTICAST_CLIENT_V4_MSEND_DONE
-	rhts-sync-block -s IPVLAN_BASIC_MULTICAST_SERVER_V6_MDUMP_READY $SERVERS
+	rstrnt-sync-set -s IPVLAN_BASIC_MULTICAST_CLIENT_V4_MSEND_DONE
+	rstrnt-sync-block -s IPVLAN_BASIC_MULTICAST_SERVER_V6_MDUMP_READY $SERVERS
 	rlRun "sleep 5"
 
 	port_num=12960
@@ -851,7 +851,7 @@ then
 		let port_num++
 		rlRun "msend -qq -f 6 -1 ff0e:1234::$i $port_num 15 $IFACE_NAME"
 	done
-	rhts-sync-set -s IPVLAN_BASIC_MULTICAST_CLIENT_V6_MSEND_DONE
+	rstrnt-sync-set -s IPVLAN_BASIC_MULTICAST_CLIENT_V6_MSEND_DONE
 
 else
 	rlRun "ip link add dummy1 type dummy"
@@ -1190,8 +1190,8 @@ then
 		rlRun "ip netns exec netns$i ip -6 route change default dev ipvlan$i || \
 			ip netns exec netns$i ip -6 route add default dev ipvlan$i"
 	done
-	rhts-sync-set -s IPVLAN_MAC_POLLUTION_SERVER_READY
-	rhts-sync-block -s IPVLAN_MAC_POLLUTION_CLIENT_DONE $CLIENTS
+	rstrnt-sync-set -s IPVLAN_MAC_POLLUTION_SERVER_READY
+	rstrnt-sync-block -s IPVLAN_MAC_POLLUTION_CLIENT_DONE $CLIENTS
 	rlRun "netns_clean.sh"
 	rlRun "modprobe -r ipvlan"
 elif i_am_client
@@ -1199,7 +1199,7 @@ then
 	rlRun "get_test_iface_and_addr"
 	rlRun "ip route add 1.1.1.0/24 dev $TEST_IFACE"
 	rlRun "ip -6 route add 1111::/64 dev $TEST_IFACE"
-	rhts-sync-block -s IPVLAN_MAC_POLLUTION_SERVER_READY $SERVERS
+	rstrnt-sync-block -s IPVLAN_MAC_POLLUTION_SERVER_READY $SERVERS
 	rlRun "ping 1.1.1.1 -c 2"
 	rlRun "ipvlan_mac=`ip neigh show | grep 1.1.1.1 | grep -o "lladdr [^ ]*" | awk '{print $2}'`"
 	for i in {2..10}
@@ -1216,7 +1216,7 @@ then
 		rlRun "ip -6 neigh show | grep \"1111::$i.*$ipvlan_mac\""
 		[ $? -ne 0 ] && rlRun -l "ip -6 neigh show"
 	done
-	rhts-sync-set -s IPVLAN_MAC_POLLUTION_CLIENT_DONE
+	rstrnt-sync-set -s IPVLAN_MAC_POLLUTION_CLIENT_DONE
 	rlRun "ip route del 1.1.1.0/24 dev $TEST_IFACE"
 	rlRun "ip -6 route del 1111::/64 dev $TEST_IFACE"
 else


### PR DESCRIPTION

Verify current restraint provides rstrnt-sync-* functionality: 
*rpm -ql restraint-0.2.0-1.el7bkr.x86_64|grep rstrnt-sync
/usr/bin/rstrnt-sync
/usr/bin/rstrnt-sync-block
/usr/bin/rstrnt-sync-set

Time to update legacy  rhts-sync with client-server restraint functionality. 
