### PR TITLE
af_alg-test: Bump ref to fix failures on 5.5+ kernels

### DIFF
--- a/packages/libkcapi/af_alg-test/runtest.sh
+++ b/packages/libkcapi/af_alg-test/runtest.sh
@@ -22,7 +22,7 @@
 . /usr/share/beakerlib/beakerlib.sh
 
 GIT_URL="https://github.com/smuellerDD/libkcapi"
-GIT_REF="v1.1.5"
+GIT_REF="c77b0cf4567e9c534378d7c5bfeceb3eda1d2d30"
 
 rlJournalStart
     rlPhaseStartSetup


### PR DESCRIPTION
Bump the upstream ref to include a fix for the failures on kernels 5.5+.
These were caused by a bug in libkcapi amd exposed by a change in kernel
5.5.

See: https://github.com/smuellerDD/libkcapi/commit/2fdd3738c77b0db825b4bb94eef9a932aa5077de

---

After this the test can be enabled also on upstream kernels.