### PR TITLE
loopdev/sanity: fix gcc10 build error

### DIFF
--- a/filesystems/loopdev/sanity/Makefile
+++ b/filesystems/loopdev/sanity/Makefile
@@ -17,7 +17,7 @@ export TEST=$(TOPLEVEL_NAMESPACE)/$(RELATIVE_PATH)
 LOOKASIDE=http://www.iozone.org/src/current
 
 # Name of the tar file that will be bundled
-TARGET=iozone3_487
+TARGET=iozone3_489
 
 FILES=	$(METADATA)      \
 	runtest.sh       \

--- a/filesystems/xfs/xfstests/xfstests-run.sh
+++ b/filesystems/xfs/xfstests/xfstests-run.sh
@@ -31,6 +31,7 @@ function check_tests()
 			echoo "The test $XFSTEST does not seem to exist."
 			continue
 		fi
+		echo "./checking $XFSTEST" > /dev/kmsg
 		MOUNT_OPTIONS="$MOUNT_OPTS" MKFS_OPTIONS="$MKFS_OPTS" xlog ./check $CHECK_OPTS $XFSTEST
 		ret=$?
 
@@ -128,6 +129,7 @@ function check()
 		popd
 		return 1
 	fi
+	echo "got RUNTESTS" > /dev/kmsg
 
 	for ((n=0;n<$LOOP;n++));do
 		check_tests

--- a/filesystems/xfs/xfstests/xfstests-setup.sh
+++ b/filesystems/xfs/xfstests/xfstests-setup.sh
@@ -160,15 +160,18 @@ function setup_test_dev_mkfs()
 		# check TEST_DEV
 		if ! blkid $TEST_DEV; then
 			echoo " * TEST_DEV $TEST_DEV looks invalid"
+			echo " * TEST_DEV $TEST_DEV looks invalid" > /dev/kmsg
 			exit 0
 		fi
 		# Make FSTYPE fs with MKFS_OPTS options on the device, exit on failure
 		if ! mkfs_dev $TEST_DEV; then
 			echoo " * mkfs_dev on TEST_DEV $TEST_DEV failed"
+			echo " * mkfs_dev on TEST_DEV $TEST_DEV failed" > /dev/kmsg
 			exit 0
 		fi
 	fi
 	echoo " * setup_test_dev_mkfs on TEST_DEV $TEST_DEV done"
+	echo " * setup_test_dev_mkfs on TEST_DEV $TEST_DEV done" > /dev/kmsg
 }
 
 # Submit block device info for debug
@@ -212,6 +215,7 @@ _EOF_
 	fi
 
 	echoo "getting blkdev info $TEST_DEV $SCRATCH_DEV $LOGWRITES_DEV"
+	echo "getting blkdev info $TEST_DEV $SCRATCH_DEV $LOGWRITES_DEV" > /dev/kmsg
 	get_blkdev_info $TEST_DEV > blockdev.info
 	get_blkdev_info $SCRATCH_DEV >> blockdev.info
 	get_blkdev_info $LOGWRITES_DEV >> blockdev.info
@@ -260,6 +264,7 @@ function setup_skiptests()
 		SKIPTESTS="$SKIPTESTS xfs/092"
 	fi
 	echoo "setup_skiptests done"
+	echo "setup_skiptests done" > /dev/kmsg
 }
 
 
@@ -300,5 +305,6 @@ function setup_full
 	sleep 10
 	sync
 
+	echo "setup_full done" > /dev/kmsg
 	report setup_done PASS 0
 }


### PR DESCRIPTION
With another commit to print more debug info for xfstests.