### PR TITLE
Disable kms02 for upstream kernels

### DIFF
--- a/distribution/ltp-upstream/include/knownissue.sh
+++ b/distribution/ltp-upstream/include/knownissue.sh
@@ -165,6 +165,8 @@ function knownissue_filter()
 	tskip "pty04" unfix
 	# https://lists.linux.it/pipermail/ltp/2020-May/017044.html
 	tskip "nm01_sh" unfix
+	# https://github.com/linux-test-project/ltp/issues/611
+	tskip "kms02" unfix
 
 	if is_rhel8; then
                 # ------- unfix ---------


### PR DESCRIPTION
This test which is run right after podman tests is using cgroup1
which differs from podman test which uses cgroup2, mixing the two
can cause bad side effects, see the following issue request for more
details.

https://github.com/linux-test-project/ltp/issues/611