### PR TITLE
kdump: Fix kexec-tools installation kexec-boot test

### DIFF
--- a/kdump/kdump-sysrq-c/runtest.sh
+++ b/kdump/kdump-sysrq-c/runtest.sh
@@ -32,7 +32,7 @@ Crash()
     if [ ! -f "${C_REBOOT}" ]; then
         # Clear previous vmcores if any and restore kdump configurations
         Cleanup
-        PrepareKdump
+        SetupKdump
 
         # Test with
         #    default kdump config

--- a/kdump/kexec-boot/runtest.sh
+++ b/kdump/kexec-boot/runtest.sh
@@ -48,6 +48,7 @@ KexecBoot()
             fi
         fi 
 
+        PrepareKdump
         # Make sure kdump service is done running 'kexec -p' load
         # So kexec -l won't compete resources with kexec -p
         # Otherwise it may fail: kexec_load failed: Device or resource busy


### PR DESCRIPTION
- Installing/Upgrading kexec-tools in kexec-boot if Fedora
- Rename PrepareKdump() to SetupKdump()
- Move installing/upgrading kexec-tools pkgs from SetupKdump to PrepareKdump

Signed-off-by: xiawu <xiawu@redhat.com>