### PR TITLE
kdump: Test restore shouldn't clear reboot flag

### DIFF
--- a/kdump/include/runtest.sh
+++ b/kdump/include/runtest.sh
@@ -851,7 +851,7 @@ RestoreKdumpConfig()
         umount "${path}"
     }
 
-    rm -f "${K_NFS}" "${K_PATH}" "${K_REBOOT}"
+    rm -f "${K_NFS}" "${K_PATH}"
 
     Log "- Restore /etc/kdump.conf"
     echo > "${KDUMP_CONFIG}"


### PR DESCRIPTION
File $K_REBOOT was wrongly cleared in RestoreKdumpConfig().
It will cause system reboot loop when KER1ARGS passed to the test requiring an extra reboot for changing boot loader.

Signed-off-by: xiawu <xiawu@redhat.com>