### PR TITLE
af_alg-test: Bump upstream ref to v1.2.0

### DIFF
--- a/packages/libkcapi/af_alg-test/runtest.sh
+++ b/packages/libkcapi/af_alg-test/runtest.sh
@@ -22,7 +22,7 @@
 . /usr/share/beakerlib/beakerlib.sh
 
 GIT_URL="https://github.com/smuellerDD/libkcapi"
-GIT_REF="c77b0cf4567e9c534378d7c5bfeceb3eda1d2d30"
+GIT_REF="v1.2.0"
 
 rlJournalStart
     rlPhaseStartSetup
@@ -34,8 +34,6 @@ rlJournalStart
     rlPhaseStartTest
         rlRun "sed -i 's/^exec_test$/exec_test; exit \$?/' libkcapi/test/test-invocation.sh" 0 \
             "Skip the compilation and 32-bit tests"
-        rlRun "sed -i '/symfunc 1 -j/d' libkcapi/test/test.sh" 0 \
-            "Skip the broken multithreaded tests"
         # NOTE: we could enable the fuzz tests with ENABLE_FUZZ_TEST=1, but
         # they take a veeeery long time to run and so far I haven't seen
         # them actually uncover a bug... Let's just keep them off for now.


### PR DESCRIPTION
The latest release disables some tests that were broken. We can now
remove the workaround and this will also fix the false positives on
machines with async crypto drivers.