### PR TITLE
kdump: Pull latest kdump/crash from F33

### DIFF
--- a/kdump/include/runtest.sh
+++ b/kdump/include/runtest.sh
@@ -360,7 +360,7 @@ PrepareKdump()
     # Try upgrading kexec-tools to the latest version if on FC.
     # If it fails, still use the kexec-tools from the default repo.
     if $IS_FC && $UPGRADE_FC_KDUMP; then
-        UpgradePackages kexec-tools dracut systemd --enablerepo=updates-testing --enablerepo=fedora --releasever=32
+        UpgradePackages kexec-tools dracut systemd --enablerepo=updates-testing --enablerepo=fedora --releasever=33
     fi
 }
 
@@ -372,7 +372,7 @@ PrepareCrash()
     # Try upgrading crash to the latest version if on FC.
     # If it fails, still use the crash from the default repo.
     if $IS_FC && $UPGRADE_FC_CRASH; then
-        UpgradePackages crash --enablerepo=updates-testing --enablerepo=fedora --releasever=32
+        UpgradePackages crash --enablerepo=updates-testing --enablerepo=fedora --releasever=33
     fi
     InstallDebuginfo
 }


### PR DESCRIPTION
Since base compose now is Fedora-32, pull latest kdump/crash packges from F-33.

Signed-off-by: xiawu <xiawu@redhat.com>